### PR TITLE
Restyled login page and made the header on side drawer larger

### DIFF
--- a/src/components/pages/Login/LoginContainer.js
+++ b/src/components/pages/Login/LoginContainer.js
@@ -1,50 +1,27 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { StyledLogin } from './LoginContainerStyled';
 import OktaSignIn from '@okta/okta-signin-widget';
 import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
+// Below is the Human Rights logo
+import hrfLogo from './hrf-logo.png';
 
 import { config } from '../../../utils/oktaConfig';
 
-import {
-  LoginDiv,
-  Header,
-  InfoDiv,
-  LoginButtonDiv,
-  SecureLogin,
-  LeftSide,
-  RightSide,
-  OverlayDiv,
-  CloseLogin,
-} from './LoginContainerStyled';
-
-import TableChartOutlinedIcon from '@material-ui/icons/TableChartOutlined';
-import CloudDoneIcon from '@material-ui/icons/CloudDone';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
-
 const LoginContainer = () => {
-  const [login, setLogin] = useState(false);
-
-  const toggleLogin = event => {
-    event.preventDefault();
-    setLogin(!login);
-  };
-
   useEffect(() => {
     const { pkce, issuer, clientId, redirectUri, scopes } = config;
-    // destructure your config so that you can pass it into the required fields in your widget.
+
     const widget = new OktaSignIn({
       baseUrl: issuer ? issuer.split('/oauth2')[0] : '',
       clientId,
       redirectUri,
-      registration: {
-        // there is more we can do to handle some errors here.
-      },
-      features: { registration: true },
+      registration: {},
+      features: { registration: false },
       // turning this feature on allows your widget to use Okta for user registration
-      logo: require('./hrf-logo.png'),
-      // add your custom logo to your signing/register widget here.
+      logo: `${hrfLogo}`, // Import any logo you want to display at the top of the login widget
       i18n: {
         en: {
-          'primaryauth.title': 'Refugee Asylum Case Database',
+          'primaryauth.title': 'Login',
           // change title for your app
         },
       },
@@ -56,65 +33,25 @@ const LoginContainer = () => {
       },
     });
 
-    if (login) {
-      widget.renderEl(
-        { el: '#sign-in-widget' },
-        () => {
-          /**
-           * In this flow, the success handler will not be called because we redirect
-           * to the Okta org for the authentication workflow.
-           */
-        },
-        err => {
-          throw err;
-        }
-      );
-    } else {
-      widget.remove();
-    }
-  }, [login]);
+    widget.renderEl(
+      { el: '#sign-in-widget' },
+      () => {
+        /**
+         * In this flow, the success handler will not be called because we redirect
+         * to the Okta org for the authentication workflow.
+         */
+      },
+      err => {
+        throw err;
+      }
+    );
+  }, []);
 
   return (
-    <LoginDiv>
-      <Header>Welcome to Human Rights First©</Header>
-
-      <InfoDiv>
-        {/* Logo, application name, 3 icons with single line description */}
-        <LeftSide>
-          <img src={require('./hrf-logo.png')} alt="An Image" />
-          <h2>
-            Refugee <br />
-            Asylum <br />
-            Case <br />
-            Database
-          </h2>
-        </LeftSide>
-        <RightSide>
-          <div>
-            <TableChartOutlinedIcon style={{ fontSize: '6rem' }} />
-            <p>Perform custom queries and analyze data</p>
-          </div>
-          <div>
-            <p>Upload &amp; download cases in PDF or CSV</p>
-            <CloudDoneIcon style={{ fontSize: '6rem' }} />
-          </div>
-          <div>
-            <DescriptionOutlinedIcon style={{ fontSize: '6rem' }} />
-            <p>Access detailed reports on Judges and Cases</p>
-          </div>
-        </RightSide>
-      </InfoDiv>
-
-      <LoginButtonDiv>
-        {!login && (
-          <SecureLogin onClick={toggleLogin}>Secure Login</SecureLogin>
-        )}
-      </LoginButtonDiv>
-
-      {login && <div id="sign-in-widget" />}
-      {login && <CloseLogin onClick={toggleLogin}>X</CloseLogin>}
-      {login && <OverlayDiv></OverlayDiv>}
-    </LoginDiv>
+    <StyledLogin>
+      <div class="background-image" aria-label="cosmetic background image" />
+      <div id="sign-in-widget" aria-label="login form" />
+    </StyledLogin>
   );
 };
 

--- a/src/components/pages/Login/LoginContainerStyled.js
+++ b/src/components/pages/Login/LoginContainerStyled.js
@@ -1,90 +1,40 @@
 import styled from 'styled-components';
+import statueOfLiberty from './statueOfLiberty.jpeg';
 
-export const LoginDiv = styled.div`
+export const StyledLogin = styled.div`
   display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100vh;
-  padding: 8vh 6% 0 6%;
+  justify-content: space-between;
+
+  .background-image {
+    background-image: url(${statueOfLiberty});
+    width: 55vw;
+    height: 100vh;
+    background-position: center;
+    background-size: cover;
+  }
 
   #sign-in-widget {
-    position: fixed;
-    top: 50vh;
-    left: 50vw;
-    transform: translate(-200px, -400px);
-    z-index: 999;
-  }
-`;
-
-export const Header = styled.h1`
-  font-size: 4rem;
-  margin-bottom: 5%;
-`;
-
-export const InfoDiv = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-export const LeftSide = styled.div`
-  width: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  img {
-    height: 8rem;
-    width: 22vw;
-    padding-right: 6%;
-  }
-  h2 {
-    font-size: 5rem;
-    margin: 0;
-    line-height: 7rem;
-  }
-`;
-export const RightSide = styled.div`
-  display: flex;
-  width: 50%;
-  flex-direction: column;
-  height: 100%;
-  justify-content: space-around;
-  align-items: center;
-  div {
     display: flex;
-    width: 85%;
-    justify-content: space-between;
     align-items: center;
-    margin: 3% 0;
-    p {
-      font-size: 2.5rem;
-      margin: 0;
+    margin: 0 auto;
+    padding-bottom: 20%;
+
+    #okta-sign-in.auth-container.main-container {
+      font-family: Helvetica, Arial, sans-serif;
+    }
+
+    .o-form-head {
+      font-size: 2.4rem;
+    }
+
+    .button-primary {
+      background: #bc541e;
+      border: 1px solid #d39460;
+    }
+
+    .button-primary:hover {
+      background: #d39460;
+      border: 1px solid #d39460;
     }
   }
-`;
-
-export const LoginButtonDiv = styled.div`
-  width: 100%;
-  padding: 0 8%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
-export const SecureLogin = styled.button``;
-
-export const OverlayDiv = styled.div`
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(127, 155, 179, 0.4);
-`;
-
-export const CloseLogin = styled.button`
-  position: absolute;
-  top: 50vh;
-  right: 50vw;
-  transform: translate(195px, -295px);
-  z-index: 999;
 `;

--- a/src/components/pages/SideDrawer/SideDrawer.js
+++ b/src/components/pages/SideDrawer/SideDrawer.js
@@ -137,7 +137,11 @@ export default function SideDrawer(props) {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap style={{ color: 'whitesmoke' }}>
+          <Typography
+            variant="h6"
+            noWrap
+            style={{ color: 'whitesmoke', fontSize: '1.5rem' }}
+          >
             Human Rights First
           </Typography>
         </Toolbar>


### PR DESCRIPTION
The login page was completely restyled, I removed just the login button which redirected to the Okta sign in widget and instead had the widget display on the login page itself. I also edited the SideDrawer.js and made the "Human Rights First" header very slightly bigger. 