### PR TITLE
bugfix/download-pdf-csv-fix

### DIFF
--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -188,21 +188,23 @@ export default function CaseTable(props) {
       headerName: 'Download',
       width: 120,
       className: 'tableHeader',
-      renderCell: params => (
-        <div>
-          <a
-            href={`${process.env.REACT_APP_API_URI}/case/${params.value}/download-pdf`}
-          >
-            PDF
-          </a>
-          <a
-            style={{ marginLeft: 20 }}
-            href={`${process.env.REACT_APP_API_URI}/case/${params.value}/download-csv`}
-          >
-            CSV
-          </a>
-        </div>
-      ),
+      renderCell: params => {
+        return (
+          <div>
+            <a
+              href={`${process.env.REACT_APP_API_URI}/case/${params.row.id}/download-pdf`}
+            >
+              PDF
+            </a>
+            <a
+              style={{ marginLeft: 20 }}
+              href={`${process.env.REACT_APP_API_URI}/case/${params.row.id}/download-csv`}
+            >
+              CSV
+            </a>
+          </div>
+        );
+      },
     },
   ];
   const classes = useStyles();


### PR DESCRIPTION
This PR updates the href value for the download-pdf and download-csv links in the download cell of the cases table. These links now work as intended and are hitting the correct endpoints on the backend.