### PR TITLE
added function to view PDF files in site

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,0 @@
-REACT_APP_CLIENT_ID=getThisFromCredentialsDoc
-REACT_APP_OKTA_ISSUER_URI=getThisFromCredentialsDoc
-REACT_APP_API_URI=getThisFromCredentialsDoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,60 @@
         "resize-observer-polyfill": "^1.5.0"
       }
     },
+    "@appbaseio/reactivecore": {
+      "version": "9.8.5",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivecore/-/reactivecore-9.8.5.tgz",
+      "integrity": "sha512-AalPcAv8JycDuZ84DWUtQckpvO3hv4BVNSF3sYNqmM6eRQKC+cIY43AIeHXUcWuAijLR3arkjsuJ7pBQfZ3AWw==",
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "prop-types": "^15.6.0",
+        "redux": "^4.0.0",
+        "redux-thunk": "^2.3.0",
+        "xdate": "^0.8.2"
+      }
+    },
+    "@appbaseio/reactivesearch": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivesearch/-/reactivesearch-3.14.2.tgz",
+      "integrity": "sha512-6nrG5jhp6tU5mkOB7KMc9Ph8g7cQityrcltLttUMxdnCWn+2ar1c4j0d2/PpzrVyWsGbH/QiJz7tNl9C1A1Daw==",
+      "requires": {
+        "@appbaseio/reactivecore": "9.8.5",
+        "@emotion/core": "^10.0.28",
+        "@emotion/styled": "^10.0.27",
+        "appbase-js": "^4.1.0",
+        "cross-env": "^5.2.0",
+        "downshift": "^1.31.2",
+        "emotion-theming": "^10.0.27",
+        "hoist-non-react-statics": "^3.2.1",
+        "polished": "^1.9.3",
+        "prop-types": "^15.6.0",
+        "react-day-picker": "^7.0.5",
+        "react-redux": "^6.0.1",
+        "rheostat": "^2.1.1",
+        "url-search-params-polyfill": "^7.0.0",
+        "xdate": "^0.8.2"
+      },
+      "dependencies": {
+        "polished": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-1.9.3.tgz",
+          "integrity": "sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ=="
+        },
+        "react-redux": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
+          "integrity": "sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.2"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -1365,7 +1419,6 @@
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
       "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "dev": true,
       "requires": {
         "@emotion/sheet": "0.9.4",
         "@emotion/stylis": "0.8.5",
@@ -1377,7 +1430,6 @@
       "version": "10.0.28",
       "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
       "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1391,7 +1443,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
       "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dev": true,
       "requires": {
         "@emotion/serialize": "^0.11.15",
         "@emotion/utils": "0.11.3",
@@ -1420,7 +1471,6 @@
       "version": "0.11.16",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
       "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "dev": true,
       "requires": {
         "@emotion/hash": "0.8.0",
         "@emotion/memoize": "0.7.4",
@@ -1432,14 +1482,12 @@
     "@emotion/sheet": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
-      "dev": true
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "@emotion/styled": {
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
       "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-      "dev": true,
       "requires": {
         "@emotion/styled-base": "^10.0.27",
         "babel-plugin-emotion": "^10.0.27"
@@ -1449,7 +1497,6 @@
       "version": "10.0.31",
       "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
       "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/is-prop-valid": "0.8.8",
@@ -1470,14 +1517,29 @@
     "@emotion/utils": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-      "dev": true
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-      "dev": true
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
+    "@fluentui/react-component-event-listener": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz",
+      "integrity": "sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==",
+      "requires": {
+        "@babel/runtime": "^7.10.4"
+      }
+    },
+    "@fluentui/react-component-ref": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz",
+      "integrity": "sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==",
+      "requires": {
+        "@babel/runtime": "^7.10.4",
+        "react-is": "^16.6.3"
+      }
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1991,6 +2053,11 @@
         "elementary-circuits-directed-graph": "^1.0.4"
       }
     },
+    "@popperjs/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-V3WyEc8ZyAuOQ2fpFuTuYYOd2tV4NePeSdxaHYgYAOs7ERLxlcFi2XsmgI5LJFdAUmJKXsg8jaIiVTkTHQygQw=="
+    },
     "@reach/router": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
@@ -2017,6 +2084,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
+    },
+    "@semantic-ui-react/event-stack": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.2.tgz",
+      "integrity": "sha512-Yd0Qf7lPCIjzJ9bZYfurlNu2RDXT6KKSyubHfYK3WjRauhxCsq6Fk2LMRI9DEvShoEU+AsLSv3NGkqXAcVp0zg==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "prop-types": "^15.6.2"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
@@ -5526,6 +5602,48 @@
       "integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
       "dev": true
     },
+    "appbase-js": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/appbase-js/-/appbase-js-4.1.2.tgz",
+      "integrity": "sha512-CS30q6Hmd6k2CXgd1Zwz6s2szsZb0A4AzDIR+MGz4r8BVcJQoeIv4PTOq0QqUCu4OXZatCMEWFe84WUfBiqjCA==",
+      "requires": {
+        "cross-fetch": "^2.2.2",
+        "json-stable-stringify": "^1.0.1",
+        "querystring": "^0.2.0",
+        "stream": "^0.0.2",
+        "url-parser-lite": "^0.1.0",
+        "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+          "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+          "requires": {
+            "node-fetch": "2.1.2",
+            "whatwg-fetch": "2.0.4"
+          }
+        },
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -6031,7 +6149,6 @@
       "version": "10.0.33",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
       "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -6048,8 +6165,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -8259,6 +8375,14 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-env": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
+      "integrity": "sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==",
+      "requires": {
+        "cross-spawn": "^6.0.5"
+      }
+    },
     "cross-fetch": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
@@ -9252,6 +9376,11 @@
       "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
       "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
     },
+    "downshift": {
+      "version": "1.31.16",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-1.31.16.tgz",
+      "integrity": "sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA=="
+    },
     "draw-svg-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
@@ -9395,6 +9524,11 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9409,7 +9543,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
       "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/weak-memoize": "0.2.5",
@@ -10202,6 +10335,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -10700,8 +10838,7 @@
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "3.0.0",
@@ -14554,6 +14691,11 @@
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
+    "keyboard-key": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -15142,6 +15284,11 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lodash-es": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
+      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -20144,6 +20291,14 @@
         "clsx": "^1.1.1"
       }
     },
+    "react-day-picker": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.8.tgz",
+      "integrity": "sha512-pp0hnxFVoRuBQcRdR1Hofw4CQtOCGVmzCNrscyvS0Q8NEc+UiYLEDqE5dk37bf0leSnBW4lheIt0CKKhuKzDVw==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -20414,8 +20569,7 @@
     "react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
       "version": "2.4.1",
@@ -21512,6 +21666,15 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
+    "rheostat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rheostat/-/rheostat-2.2.0.tgz",
+      "integrity": "sha512-cO6MvZ3fXtgP7NH7smWZhZczropunZJ50cdCLdlXR5Rhw0FNRaMM23Wx4NJjs5TGta3jOec39A/L0Lg8h8bPRQ==",
+      "requires": {
+        "object.assign": "^4.1.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "rifm": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.7.0.tgz",
@@ -21803,6 +21966,37 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
         "node-forge": "^0.10.0"
+      }
+    },
+    "semantic-ui-react": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.0.3.tgz",
+      "integrity": "sha512-a0hGN6XXw64sRSKwWqMCKSI/AGLohxNeWuErS39eswvBbUnLjBij8ZoEdiqDiz/PuWpwYIRjgmQVrut+7h3b2g==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@fluentui/react-component-event-listener": "~0.51.6",
+        "@fluentui/react-component-ref": "~0.51.6",
+        "@popperjs/core": "^2.6.0",
+        "@semantic-ui-react/event-stack": "^3.1.2",
+        "clsx": "^1.1.1",
+        "keyboard-key": "^1.1.0",
+        "lodash": "^4.17.19",
+        "lodash-es": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6 || ^17.0.0",
+        "react-popper": "^2.2.4",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-popper": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.4.tgz",
+          "integrity": "sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==",
+          "requires": {
+            "react-fast-compare": "^3.0.1",
+            "warning": "^4.0.2"
+          }
+        }
       }
     },
     "semver": {
@@ -22665,6 +22859,14 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.11.2.tgz",
       "integrity": "sha512-TQMKs+C6n9idtzLpxluikmDCYiDJrTbbIGn9LFxMg0BVTu+8JZKSlXTWYRpOFKlfKD5HlDWLVpJJyNGZ2e9l1A==",
       "dev": true
+    },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -23936,6 +24138,16 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "url-parser-lite": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/url-parser-lite/-/url-parser-lite-0.1.0.tgz",
+      "integrity": "sha512-k8eUA7I5qfH6c1ZI9CvdHEk+YH1KroX2ry+FF9k6yJBl7AmDWen2WI+xNzbCBAek6JEvgPBoHub4v8aZIM7Jqw=="
+    },
+    "url-search-params-polyfill": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz",
+      "integrity": "sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ=="
     },
     "use": {
       "version": "3.1.1",
@@ -25415,6 +25627,11 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xdate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.2.tgz",
+      "integrity": "sha1-17AzwASF0CaVuvAET06s2j/JYaM="
     },
     "xhr2": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "repository": "github:Lambda-School-Labs/labs-spa-starter",
   "dependencies": {
+    "@appbaseio/reactivesearch": "^3.14.2",
     "@craco/craco": "^5.6.4",
     "@date-io/date-fns": "^2.10.6",
     "@material-ui/core": "^4.11.2",
@@ -35,6 +36,7 @@
     "react-scripts": "3.4.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "semantic-ui-react": "^2.0.3",
     "styled-components": "^5.2.1"
   },
   "scripts": {

--- a/src/components/pages/CaseOverview/CaseOverviewStyled.js
+++ b/src/components/pages/CaseOverview/CaseOverviewStyled.js
@@ -12,7 +12,7 @@ export const Container = styled.div`
 
 // CASE/JUDGE CONTAINER
 export const CaseSpecs = styled.div`
-  border-radius: 30px;
+  border-radius: 2px;
   box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
@@ -25,7 +25,7 @@ export const CaseSpecs = styled.div`
 
 // CLIENT CONTAINER
 export const ClientSpecs = styled.div`
-  border-radius: 30px;
+  border-radius: 2px;
   box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
@@ -38,7 +38,7 @@ export const ClientSpecs = styled.div`
 
 // RESULTS
 export const Results = styled.div`
-  border-radius: 30px;
+  border-radius: 2px;
   box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -12,7 +12,7 @@ import SaveButton from './SaveButton';
 // Imports for PDF Modal
 import PDFViewer from '../PDFViewer/PDFViewer';
 import { Button } from 'antd';
-import pdf from '../PDFViewer/samplePDF.pdf';
+import pdf from '../PDFViewer/samplePDF 2.pdf';
 import './CaseTable.css';
 
 const useStyles = makeStyles(theme => ({
@@ -71,6 +71,12 @@ export default function CaseTable(props) {
   const [showPdf, setShowPdf] = useState(false);
   const columns = [
     {
+      field: 'hearing_date',
+      headerName: 'Hearing Date',
+      width: 150,
+      className: 'tableHeader',
+    },
+    {
       field: 'id',
       headerName: 'Case ID',
       width: 200,
@@ -79,6 +85,7 @@ export default function CaseTable(props) {
         filter: true,
       },
       //link to individual case page
+
       renderCell: params => (
         <>
           <Link to={`/case/${params.value}`} style={{ color: '#215589' }}>
@@ -148,11 +155,11 @@ export default function CaseTable(props) {
         <>
           <div className={classes.pdfView}>
             <PDFViewer
-              pdf={pdf}
+              pdf={pdf} // this will be set to viewPdf when endpoint is available
               onCancel={() => setShowPdf(false)}
               visible={showPdf}
             />
-            <Button onClick={() => setShowPdf(!showPdf)}>PDF</Button>
+            <Button onClick={viewPdf}>PDF</Button>
           </div>
         </>
       ),
@@ -182,6 +189,22 @@ export default function CaseTable(props) {
       },
     },
   ];
+
+  // function to show pdf data from backend endpoint in pdf viewer
+  // depending on what case is selected
+  const viewPdf = () => {
+    setShowPdf(!showPdf);
+    axios
+      .get('http://localhost:3000/') // dummy data for now. No endpoints exist
+      .then(res => {
+        console.log(res);
+        if (!res) {
+          console.log(
+            'This case does not have a pdf. It was uploded using CSV'
+          );
+        }
+      });
+  };
   const classes = useStyles();
 
   const handleChange = event => {
@@ -276,6 +299,7 @@ export default function CaseTable(props) {
             <MenuItem value="" disabled>
               Search By...
             </MenuItem>
+            <MenuItem value="hearing_date">Hearing Date</MenuItem>
             <MenuItem value="id">Case ID</MenuItem>
             <MenuItem value="judge_name">Judge Name</MenuItem>
             <MenuItem value="hearing_location">Venue</MenuItem>


### PR DESCRIPTION
This request adds a function that will allow a user to view the pdf form of the case file sent from a backend end point that currently does not exist to view in site through the pdf button on the main page. This request also adds a column to the CaseTable.js file that shows the date of the hearing and is searchable so the end user can search by date of hearing. This was not a part of release 1 but it is finished.

This request links to the user story: As an administrator, I can review and edit case information before approving or rejecting it. It also links to the user story: As a RR, I can review and edit case information before submitting it. The hearing date user story is: As a user, I can filter search results by time period

There is no immediate change to the output for view_pdf because there are currently no endpoints to view the pdf's. Dummy data is provided and commented in the code. There is a new column for date of hearing in the CaseTable.js file.

