### PR TITLE
fixed case table to pull from primary_key but display as case_id and …

### DIFF
--- a/src/components/pages/CaseOverview/CaseOverview.js
+++ b/src/components/pages/CaseOverview/CaseOverview.js
@@ -49,7 +49,7 @@ const CaseOverview = props => {
               type="primary"
               size="small"
               padding="15px"
-              onclick={`/case/${caseData.id}/update`}
+              onClick={`/case/${caseData.id}/update`}
             >
               Update this Case
             </Button>
@@ -63,7 +63,9 @@ const CaseOverview = props => {
             </KeyParagraph>
             <KeyParagraph>
               Judge:
-              <Link to={`/judge/${caseData.judge}`}>{caseData.judge}</Link>
+              <Link to={`/judge/${caseData.judge_name}`}>
+                {caseData.judge_name}
+              </Link>
             </KeyParagraph>
             <KeyParagraph>Court Type: {caseData.court_type}</KeyParagraph>
           </CaseSpecs>

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -132,14 +132,7 @@ export default function CaseTable(props) {
 
   const columns = [
     {
-      field: 'id',
-      hide: true,
-      headerName: 'ID',
-      width: 130,
-      className: 'tableHeader',
-    },
-    {
-      field: 'case_id',
+      field: 'primary_key',
       headerName: 'Case ID',
       width: 130,
       className: 'tableHeader',
@@ -151,7 +144,7 @@ export default function CaseTable(props) {
       renderCell: params => (
         <>
           <Link to={`/case/${params.value}`} style={{ color: '#215589' }}>
-            <span>{params.value}</span>
+            <span>{params.row['case_id']}</span>
           </Link>
         </>
       ),
@@ -163,7 +156,7 @@ export default function CaseTable(props) {
       className: 'tableHeader',
     },
     {
-      field: 'judge',
+      field: 'judge_name',
       headerName: 'Judge',
       width: 160,
       className: 'tableHeader',


### PR DESCRIPTION
Fixed case table so that it's now pulling from the primary_key to to render the table but is displaying the case_id in the appropriate column and takes the user to the correct case overview on click. Also changed judge back to judge_name on the case overview page in order to display the name again.