### PR TITLE
Made headers on cases and judges tables bold

### DIFF
--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -26,10 +26,6 @@ const useStyles = makeStyles(theme => ({
   grid: {
     marginTop: 15,
   },
-  tableHeader: {
-    color: 'red',
-    fontWeight: 'normal',
-  },
   tbl_container: {
     display: 'flex',
     flexDirection: 'column',

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -26,6 +26,10 @@ const useStyles = makeStyles(theme => ({
   grid: {
     marginTop: 15,
   },
+  tableHeader: {
+    color: 'red',
+    fontWeight: 'normal',
+  },
   tbl_container: {
     display: 'flex',
     flexDirection: 'column',
@@ -147,7 +151,7 @@ export default function CaseTable(props) {
   const columns = [
     {
       field: 'primary_key',
-      headerName: 'Case ID',
+      renderHeader: params => <strong>{'Case ID'}</strong>,
       width: 130,
       className: 'tableHeader',
       options: {
@@ -158,20 +162,20 @@ export default function CaseTable(props) {
       renderCell: params => (
         <>
           <Link to={`/case/${params.value}`} style={{ color: '#215589' }}>
-            <span>{params.row['case_id']}</span>
+            <span> {params.row['case_id']}</span>
           </Link>
         </>
       ),
     },
     {
       field: 'hearing_date',
-      headerName: 'Date',
+      renderHeader: params => <strong>{'Date'}</strong>,
       width: 110,
       className: 'tableHeader',
     },
     {
       field: 'judge_name',
-      headerName: 'Judge',
+      renderHeader: params => <strong>{'Judge'}</strong>,
       width: 160,
       className: 'tableHeader',
       renderCell: params => (
@@ -187,83 +191,95 @@ export default function CaseTable(props) {
     },
     {
       field: 'initial_or_appellate',
-      headerName: 'Initial Hearing',
+      renderHeader: params => <strong>{'Initial Hearing'}</strong>,
       width: 120,
       className: 'tableHeader',
     },
     {
       field: 'case_origin',
-      headerName: 'Case Origin',
+      renderHeader: params => <strong>{'Case Origin'}</strong>,
+      // headerName: 'Case Origin',
       width: 160,
       className: 'tableHeader',
     },
     {
       field: 'case_filed_within_one_year',
-      headerName: 'Filed 1 Year',
+      renderHeader: params => <strong>{'Filed 1 Year'}</strong>,
+      // headerName: 'Filed 1 Year',
       width: 110,
       className: 'tableHeader',
     },
     {
       field: 'protected_ground',
-      headerName: 'Protected Ground',
+      renderHeader: params => <strong>{'Protected Ground'}</strong>,
+      // headerName: 'Protected Ground',
       width: 145,
       className: 'tableHeader',
     },
     {
       field: 'case_outcome',
-      headerName: 'Outcome',
+      renderHeader: params => <strong>{'Outcome'}</strong>,
+      // headerName: 'Outcome',
       width: 110,
       className: 'tableHeader',
     },
     {
       field: 'nation_of_origin',
-      headerName: 'Nation of Origin',
+      renderHeader: params => <strong>{'Nation of Origin'}</strong>,
+      // headerName: 'Nation of Origin',
       width: 135,
       className: 'tableHeader',
     },
     {
       field: 'applicant_gender',
-      headerName: 'Applicant Gender',
+      renderHeader: params => <strong>{'Applicant Gender'}</strong>,
+      // headerName: 'Applicant Gender',
       width: 145,
       className: 'tableHeader',
     },
     {
       field: 'type_of_violence_experienced',
-      headerName: 'Violence Experienced',
+      renderHeader: params => <strong>{'Violence Experienced'}</strong>,
+      // headerName: 'Violence Experienced',
       width: 175,
       className: 'tableHeader',
     },
     {
       field: 'application_type',
-      headerName: 'Application Type ',
+      renderHeader: params => <strong>{'Application Type'}</strong>,
+      // headerName: 'Application Type ',
       width: 140,
       className: 'tableHeader',
       hide: true,
     },
     {
       field: 'applicant_indigenous_group',
-      headerName: 'Indigenous Group',
+      renderHeader: params => <strong>{'Indigenous Group'}</strong>,
+      // headerName: 'Indigenous Group',
       width: 150,
       className: 'tableHeader',
       hide: true,
     },
     {
       field: 'applicant_language',
-      headerName: 'Applicant Language',
+      renderHeader: params => <strong>{'Applicant Language'}</strong>,
+      // headerName: 'Applicant Language',
       width: 160,
       className: 'tableHeader',
       hide: true,
     },
     {
       field: 'applicant_access_to_interpreter',
-      headerName: 'Interpreter',
+      renderHeader: params => <strong>{'Interpreter'}</strong>,
+      // headerName: 'Interpreter',
       width: 100,
       className: 'tableHeader',
       hide: true,
     },
     {
       field: 'applicant_perceived_credibility',
-      headerName: 'Applicant Credibility',
+      renderHeader: params => <strong>{'Applicant Credibility'}</strong>,
+      // headerName: 'Applicant Credibility',
       width: 160,
       className: 'tableHeader',
       hide: true,
@@ -608,6 +624,7 @@ export default function CaseTable(props) {
           {drawerContent()}
         </Drawer>
       </div>
+      {/* <div className={classes.dataGridContainer}> */}
       <DataGrid
         rows={searching ? filter(caseData) : caseData}
         columns={columns}
@@ -620,6 +637,7 @@ export default function CaseTable(props) {
         disableColumnMenu={true}
         components={{ Toolbar: Toolbar }}
       />
+      {/* </div> */}
     </div>
   );
 }

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -192,7 +192,7 @@ export default function CaseTable(props) {
     {
       field: 'initial_or_appellate',
       renderHeader: params => <strong>{'Initial Hearing'}</strong>,
-      width: 120,
+      width: 130,
       className: 'tableHeader',
     },
     {
@@ -204,13 +204,13 @@ export default function CaseTable(props) {
     {
       field: 'case_filed_within_one_year',
       renderHeader: params => <strong>{'Filed 1 Year'}</strong>,
-      width: 110,
+      width: 115,
       className: 'tableHeader',
     },
     {
       field: 'protected_ground',
       renderHeader: params => <strong>{'Protected Ground'}</strong>,
-      width: 145,
+      width: 155,
       className: 'tableHeader',
     },
     {
@@ -222,19 +222,19 @@ export default function CaseTable(props) {
     {
       field: 'nation_of_origin',
       renderHeader: params => <strong>{'Nation of Origin'}</strong>,
-      width: 135,
+      width: 140,
       className: 'tableHeader',
     },
     {
       field: 'applicant_gender',
       renderHeader: params => <strong>{'Applicant Gender'}</strong>,
-      width: 145,
+      width: 155,
       className: 'tableHeader',
     },
     {
       field: 'type_of_violence_experienced',
       renderHeader: params => <strong>{'Violence Experienced'}</strong>,
-      width: 175,
+      width: 185,
       className: 'tableHeader',
     },
     {

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -608,7 +608,6 @@ export default function CaseTable(props) {
           {drawerContent()}
         </Drawer>
       </div>
-      {/* <div className={classes.dataGridContainer}> */}
       <DataGrid
         rows={searching ? filter(caseData) : caseData}
         columns={columns}
@@ -621,7 +620,6 @@ export default function CaseTable(props) {
         disableColumnMenu={true}
         components={{ Toolbar: Toolbar }}
       />
-      {/* </div> */}
     </div>
   );
 }

--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -198,56 +198,48 @@ export default function CaseTable(props) {
     {
       field: 'case_origin',
       renderHeader: params => <strong>{'Case Origin'}</strong>,
-      // headerName: 'Case Origin',
       width: 160,
       className: 'tableHeader',
     },
     {
       field: 'case_filed_within_one_year',
       renderHeader: params => <strong>{'Filed 1 Year'}</strong>,
-      // headerName: 'Filed 1 Year',
       width: 110,
       className: 'tableHeader',
     },
     {
       field: 'protected_ground',
       renderHeader: params => <strong>{'Protected Ground'}</strong>,
-      // headerName: 'Protected Ground',
       width: 145,
       className: 'tableHeader',
     },
     {
       field: 'case_outcome',
       renderHeader: params => <strong>{'Outcome'}</strong>,
-      // headerName: 'Outcome',
       width: 110,
       className: 'tableHeader',
     },
     {
       field: 'nation_of_origin',
       renderHeader: params => <strong>{'Nation of Origin'}</strong>,
-      // headerName: 'Nation of Origin',
       width: 135,
       className: 'tableHeader',
     },
     {
       field: 'applicant_gender',
       renderHeader: params => <strong>{'Applicant Gender'}</strong>,
-      // headerName: 'Applicant Gender',
       width: 145,
       className: 'tableHeader',
     },
     {
       field: 'type_of_violence_experienced',
       renderHeader: params => <strong>{'Violence Experienced'}</strong>,
-      // headerName: 'Violence Experienced',
       width: 175,
       className: 'tableHeader',
     },
     {
       field: 'application_type',
       renderHeader: params => <strong>{'Application Type'}</strong>,
-      // headerName: 'Application Type ',
       width: 140,
       className: 'tableHeader',
       hide: true,
@@ -255,7 +247,6 @@ export default function CaseTable(props) {
     {
       field: 'applicant_indigenous_group',
       renderHeader: params => <strong>{'Indigenous Group'}</strong>,
-      // headerName: 'Indigenous Group',
       width: 150,
       className: 'tableHeader',
       hide: true,
@@ -263,7 +254,6 @@ export default function CaseTable(props) {
     {
       field: 'applicant_language',
       renderHeader: params => <strong>{'Applicant Language'}</strong>,
-      // headerName: 'Applicant Language',
       width: 160,
       className: 'tableHeader',
       hide: true,
@@ -271,7 +261,6 @@ export default function CaseTable(props) {
     {
       field: 'applicant_access_to_interpreter',
       renderHeader: params => <strong>{'Interpreter'}</strong>,
-      // headerName: 'Interpreter',
       width: 100,
       className: 'tableHeader',
       hide: true,
@@ -279,7 +268,6 @@ export default function CaseTable(props) {
     {
       field: 'applicant_perceived_credibility',
       renderHeader: params => <strong>{'Applicant Credibility'}</strong>,
-      // headerName: 'Applicant Credibility',
       width: 160,
       className: 'tableHeader',
       hide: true,

--- a/src/components/pages/JudgeTable/JudgeTable.js
+++ b/src/components/pages/JudgeTable/JudgeTable.js
@@ -73,7 +73,7 @@ export default function JudgeTable(props) {
   const columns = [
     {
       field: 'name',
-      headerName: 'Judge',
+      renderHeader: params => <strong>{'Judge'}</strong>,
       width: 170,
       color: 'navy',
       //Link to individual judge page
@@ -88,11 +88,31 @@ export default function JudgeTable(props) {
         </>
       ),
     },
-    { field: 'judge_county', headerName: 'Case Origin', width: 160 },
-    { field: 'date_appointed', headerName: 'Date Appointed', width: 140 },
-    { field: 'appointed_by', headerName: 'Appointed by', width: 160 },
-    { field: 'denial_rate', headerName: '% Denial', width: 110 },
-    { field: 'approval_rate', headerName: '% Approval', width: 110 },
+    {
+      field: 'judge_county',
+      renderHeader: params => <strong>{'Case Origin'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'date_appointed',
+      renderHeader: params => <strong>{'Date Appointed'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'appointed_by',
+      renderHeader: params => <strong>{'Appointed By'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'denial_rate',
+      renderHeader: params => <strong>{'% Denial'}</strong>,
+      width: 110,
+    },
+    {
+      field: 'approval_rate',
+      renderHeader: params => <strong>{'% Approval'}</strong>,
+      width: 130,
+    },
   ];
 
   judgeData.forEach((item, idx) => {

--- a/src/components/pages/SavedCases/SavedCases.js
+++ b/src/components/pages/SavedCases/SavedCases.js
@@ -40,7 +40,7 @@ function SavedCases({ savedCases, deleteBookmark }) {
   const columns = [
     {
       field: 'primary_key',
-      headerName: 'Case ID',
+      renderHeader: params => <strong>{'Case ID'}</strong>,
       width: 130,
       options: {
         filter: true,
@@ -54,17 +54,45 @@ function SavedCases({ savedCases, deleteBookmark }) {
         </>
       ),
     },
-    { field: 'court_type', headerName: 'Court Type', width: 105 },
-    { field: 'nation_of_origin', headerName: 'Nation of Origin', width: 130 },
-    { field: 'protected_ground', headerName: 'Protected Ground', width: 150 },
-    { field: 'application_type ', headerName: 'Application Type ', width: 130 },
-    { field: 'judge', headerName: 'Judge', width: 120 },
-    { field: 'case_outcome', headerName: 'Decision', width: 90 },
-    { field: 'case_status', headerName: 'Case Status', width: 110 },
+    {
+      field: 'court_type',
+      renderHeader: params => <strong>{'Court Type'}</strong>,
+      width: 125,
+    },
+    {
+      field: 'nation_of_origin',
+      renderHeader: params => <strong>{'Nation Of Origin'}</strong>,
+      width: 170,
+    },
+    {
+      field: 'protected_ground',
+      renderHeader: params => <strong>{'Protected Ground'}</strong>,
+      width: 180,
+    },
+    {
+      field: 'application_type ',
+      renderHeader: params => <strong>{'Application Type'}</strong>,
+      width: 175,
+    },
+    {
+      field: 'judge',
+      renderHeader: params => <strong>{'Judge'}</strong>,
+      width: 120,
+    },
+    {
+      field: 'case_outcome',
+      renderHeader: params => <strong>{'Decision'}</strong>,
+      width: 115,
+    },
+    {
+      field: 'case_status',
+      renderHeader: params => <strong>{'Case Status'}</strong>,
+      width: 140,
+    },
 
     {
       field: 'download',
-      headerName: 'Download',
+      renderHeader: params => <strong>{'Download'}</strong>,
       width: 120,
       renderCell: params => (
         <div>
@@ -85,7 +113,7 @@ function SavedCases({ savedCases, deleteBookmark }) {
     },
     {
       field: 'remove_case',
-      headerName: 'Remove',
+      renderHeader: params => <strong>{'Remove'}</strong>,
       width: 110,
       renderCell: params => (
         <IconButton>

--- a/src/components/pages/SavedJudges/SavedJudges.js
+++ b/src/components/pages/SavedJudges/SavedJudges.js
@@ -56,7 +56,7 @@ function SavedJudges({ savedJudges, deleteSavedJudge }) {
     // { field: 'id', headerName: 'id', width: 100 },
     {
       field: 'name',
-      headerName: 'Judge',
+      renderHeader: params => <strong>{'Judge'}</strong>,
       width: 170,
       color: 'navy',
       //Link to individual judge page
@@ -71,14 +71,35 @@ function SavedJudges({ savedJudges, deleteSavedJudge }) {
         </>
       ),
     },
-    { field: 'judge_county', headerName: 'Court Location', width: 160 },
-    { field: 'date_appointed', headerName: 'Date Appointed', width: 140 },
-    { field: 'appointed_by', headerName: 'Appointed by', width: 160 },
-    { field: 'denial_rate', headerName: '% Denial', width: 110 },
-    { field: 'approval_rate', headerName: '% Approval', width: 110 },
+    {
+      field: 'judge_county',
+      renderHeader: params => <strong>{'Court Location'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'date_appointed',
+      renderHeader: params => <strong>{'Date Appointed'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'appointed_by',
+      renderHeader: params => <strong>{'Appointed By'}</strong>,
+      width: 160,
+    },
+    {
+      field: 'denial_rate',
+      renderHeader: params => <strong>{'% Denial'}</strong>,
+      width: 110,
+    },
+    {
+      field: 'approval_rate',
+      renderHeader: params => <strong>{'% Approval'}</strong>,
+      width: 140,
+    },
     {
       field: 'remove_judge',
-      headerName: 'Remove',
+      renderHeader: params => <strong>{'Remove'}</strong>,
+
       width: 110,
       renderCell: params => (
         <IconButton>


### PR DESCRIPTION
The headers on the Cases and Judges tables needed to be bold in order to give users a clear indication of what kind of data each column of the tables holds.