### PR TITLE
prevents sending empty file to backend if user cancels upload

### DIFF
--- a/src/components/pages/Upload/UploadCase.js
+++ b/src/components/pages/Upload/UploadCase.js
@@ -192,6 +192,11 @@ const UploadCase = props => {
   const onFileChange = e => {
     const dataForm = new FormData();
     dataForm.append('target_file', e.target.files[0]);
+
+    if (e.target.files.length === 0) {
+      return;
+    }
+
     axios
       .post(`${process.env.REACT_APP_API_URI}/upload/`, dataForm)
       .catch(err => console.log(err));


### PR DESCRIPTION
Found a bug where if a user successfully sends a file once, then attempts another upload but cancels in the dialog box, an empty file will be sent to the back end. Added a check to onFileChange to exit the function if the file is empty.