### PR TITLE
changed defaultSelectedKeys of SideDrawer Menu to reflect current path

### DIFF
--- a/src/components/pages/SideDrawer/SideDrawer.js
+++ b/src/components/pages/SideDrawer/SideDrawer.js
@@ -27,7 +27,7 @@ function SideDrawer() {
   return (
     <div style={{ width: 246, height: '100vh' }}>
       <Menu
-        defaultSelectedKeys={['/']}
+        defaultSelectedKeys={[window.location.pathname]}
         mode="inline"
         theme="light"
         inlineCollapsed={collapsed}


### PR DESCRIPTION
## Description

- If page was manually refreshed, side drawer would highlight 'Home' no matter what page you were on

Fixes # (issue)

- Set defaultSelecteKeys = {[window.location.pathname]} instead of {['/']}

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
