### PR TITLE
fixes broken CaseTable component, adds link to JudgePage

### DIFF
--- a/src/components/pages/CaseTable/CaseTable.js
+++ b/src/components/pages/CaseTable/CaseTable.js
@@ -94,10 +94,10 @@ export default function CaseTable(props) {
       renderCell: params => (
         <>
           <Link
-            to={`/judge/${params.value.split(' ').join('%20')}`}
+            to={`/judge/${params.row.judge_id}`}
             style={{ color: '#3582cf' }}
           >
-            {params.value}
+            {params.row.first_name + ' ' + params.row.last_name}
           </Link>
         </>
       ),


### PR DESCRIPTION
## Description

Spotted an issue where the Judge column in the table on the cases page was trying to split a non-existent value to create a link to each judge's individual page. Fixed the bug, and added the ability to actually click into each JudgePage from the cases component.

Fixes # (issue)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
