### PR TITLE
Datahub table modebar

### DIFF
--- a/src/components/pages/DataHub/DataHub.js
+++ b/src/components/pages/DataHub/DataHub.js
@@ -170,6 +170,7 @@ const DataHub = props => {
 
   return (
     <div className="dataHubContainer">
+      <h1>Approvals VS Denials Nationwide</h1>
       <div className="mainChartContainer">
         <TestDataChart />
       </div>

--- a/src/components/pages/DataHub/DataHub.js
+++ b/src/components/pages/DataHub/DataHub.js
@@ -88,6 +88,24 @@ const DataHub = props => {
           },
         ]}
         layout={{ width: 500, height: 300, title: 'Case Data' }}
+        config={{
+          modeBarButtonsToRemove: [
+            'toImage',
+            'zoom2d',
+            'pan2d',
+            'select2d',
+            'lasso2d',
+            'drawclosedpath',
+            'drawopenpath',
+            'zoomIn2d',
+            'zoomOut2d',
+            'autoScale2d',
+            'hoverClosestCartesian',
+            'hoverCompareCartesian',
+            'toggleSpikelines',
+          ],
+          displaylogo: false,
+        }}
       />
     );
   };
@@ -128,6 +146,24 @@ const DataHub = props => {
           },
         ]}
         layout={{ width: 1100, height: 400, title: 'Case Data' }}
+        config={{
+          modeBarButtonsToRemove: [
+            'toImage',
+            'zoom2d',
+            'pan2d',
+            'select2d',
+            'lasso2d',
+            'drawclosedpath',
+            'drawopenpath',
+            'zoomIn2d',
+            'zoomOut2d',
+            'autoScale2d',
+            'hoverClosestCartesian',
+            'hoverCompareCartesian',
+            'toggleSpikelines',
+          ],
+          displaylogo: false,
+        }}
       />
     );
   };

--- a/src/components/pages/DataHub/DataHub.js
+++ b/src/components/pages/DataHub/DataHub.js
@@ -25,7 +25,31 @@ const DataHub = props => {
   }, [user.authState.idToken.idToken]);
 
   const TestDataChart = () => {
-    return <Plot data={vizData.data} layout={vizData.layout} />;
+    console.log(vizData.layout);
+    return (
+      <Plot
+        data={vizData.data}
+        layout={vizData.layout}
+        config={{
+          modeBarButtonsToRemove: [
+            'toImage',
+            'zoom2d',
+            'pan2d',
+            'select2d',
+            'lasso2d',
+            'drawclosedpath',
+            'drawopenpath',
+            'zoomIn2d',
+            'zoomOut2d',
+            'autoScale2d',
+            'hoverClosestCartesian',
+            'hoverCompareCartesian',
+            'toggleSpikelines',
+          ],
+          displaylogo: false,
+        }}
+      />
+    );
   };
 
   const CaseDataChart = () => {

--- a/src/components/pages/DataHub/DataHub.js
+++ b/src/components/pages/DataHub/DataHub.js
@@ -25,7 +25,6 @@ const DataHub = props => {
   }, [user.authState.idToken.idToken]);
 
   const TestDataChart = () => {
-    console.log(vizData.layout);
     return (
       <Plot
         data={vizData.data}

--- a/src/components/pages/DataHub/DataHub.less
+++ b/src/components/pages/DataHub/DataHub.less
@@ -1,3 +1,16 @@
+.dataHubContainer {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    h1 {
+        margin: 0 auto;
+        font-size: 1.8rem;
+        font-weight: bold;
+    }
+}
+
 .mainChartContainer {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Description

This pull request removes unnecessary options from the Plotly chart's modebar as discussed. Also added a header for the datahub to describe the main chart - this is a placeholder until we get a real overview visualization in there.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
