### PR TITLE
table alerts and post judge to judge id

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -7,13 +7,16 @@ import {
   SearchOutlined,
   FileTextOutlined,
   FilePdfOutlined,
+  CloseCircleOutlined,
+  CheckCircleOutlined,
 } from '@ant-design/icons';
 import Save from '../../../styles/icons/save.svg';
 import Icon from '@ant-design/icons';
 
-import { Table, Space, Button, Input, Tabs } from 'antd';
+import { Table, Space, Button, Input, Tabs, notification } from 'antd';
 import './CaseTable.less';
 import CaseDetails from '../CaseOverview/CaseDetails';
+import OrangeLine from '../../../styles/orange-line.svg';
 
 export default function CaseTable(props) {
   const [state, setState] = useState({
@@ -316,7 +319,13 @@ export default function CaseTable(props) {
 
   const bookmarkCases = selectedRowID => {
     if (selectedRowID.length === 0) {
-      alert('Please select cases(s) to be saved');
+      notification.open({
+        message: 'Saved Status',
+        description: 'Please select cases(s) to be saved',
+        top: 128,
+        duration: 8,
+        icon: <CloseCircleOutlined style={{ color: 'red' }} />,
+      });
     } else {
       let bookmarks = [];
       selectedRowID.forEach(row => bookmarks.push(findRowByID(row, caseData)));
@@ -333,7 +342,12 @@ export default function CaseTable(props) {
           postBookmark(b.case_id);
         }
       });
-      alert('Cases Successfully Saved');
+      notification.open({
+        message: 'Saved Status',
+        description: 'Case(s) Successfully Saved',
+        top: 128,
+        icon: <CheckCircleOutlined style={{ color: 'green' }} />,
+      });
     }
   };
 
@@ -477,8 +491,6 @@ export default function CaseTable(props) {
         layout={{ width: 500, height: 300, title: 'Case Data' }}
       />
     );
-
-
   };
 
   const nonAppCases = casesData.filter(item => item.appellate === false);
@@ -486,7 +498,6 @@ export default function CaseTable(props) {
 
   return (
     <div className="cases-container">
-
       <h2 className="h1Styles">Cases</h2>
       <p className="divider">
         <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />

--- a/src/components/pages/JudgeTable/JudgeTable.js
+++ b/src/components/pages/JudgeTable/JudgeTable.js
@@ -2,8 +2,12 @@ import React, { useState } from 'react';
 import axiosWithAuth from '../../../utils/axiosWithAuth';
 import { Link } from 'react-router-dom';
 import Highlighter from 'react-highlight-words';
-import { SearchOutlined } from '@ant-design/icons';
-import { Table, Space, Button, Input, Tabs } from 'antd';
+import {
+  SearchOutlined,
+  CloseCircleOutlined,
+  CheckCircleOutlined,
+} from '@ant-design/icons';
+import { Table, Space, Button, Input, Tabs, notification } from 'antd';
 import './_JudgeTableStyles.less';
 
 import Save from '../../../styles/icons/save.svg';
@@ -205,8 +209,7 @@ export default function JudgeTable(props) {
     for (let i = 0; i < rowData.length; i++) {
       let currentRow = rowData[i];
 
-      let adjustedRowID = parseInt(rowID) + 1;
-      if (currentRow.judge_id === adjustedRowID) {
+      if (currentRow.judge_id === rowID) {
         return currentRow;
       }
     }
@@ -227,26 +230,37 @@ export default function JudgeTable(props) {
   const bookmarkJudges = targetRows => {
     let bookmarks = [];
     if (targetRows.length === 0) {
-      alert('Please select judge(s) to be saved');
+      notification.open({
+        message: 'Saved Status',
+        description: 'Please select judge(s) to be saved',
+        top: 128,
+        duration: 8,
+        icon: <CloseCircleOutlined style={{ color: 'red' }} />,
+      });
     } else {
       for (let i = 0; i < targetRows.length; i++) {
         bookmarks.push(findRowByID(targetRows[i], judgeData));
       }
 
-      let savedNames = [];
+      let savedIDs = [];
       for (let i = 0; i < savedJudges.length; i++) {
-        savedNames.push(savedJudges[i].first_name);
+        savedIDs.push(savedJudges[i].judge_id);
       }
 
       for (let i = 0; i < bookmarks.length; i++) {
-        if (savedNames.includes(bookmarks[i].first_name)) {
+        if (savedIDs.includes(bookmarks[i].judge_id)) {
           console.log('Judge already saved to bookmarks');
           continue;
         } else {
           postJudge(bookmarks[i]);
         }
       }
-      alert('Judge(s) Successfully Saved');
+      notification.open({
+        message: 'Saved Status',
+        description: 'Judge(s) Successfully Saved',
+        top: 128,
+        icon: <CheckCircleOutlined style={{ color: 'green' }} />,
+      });
     }
   };
 


### PR DESCRIPTION
changed judge/case table alerts to styled notifications.  Changed judge saving to judge_id vs first_name.

![6027E7BF-C3A1-492D-91B5-A026A6D563D8_1_105_c](https://user-images.githubusercontent.com/70232643/119745133-606ff100-be42-11eb-8195-049fc1726e38.jpeg)


![3C7A1AD0-1A9A-4566-8E0D-88F316B76780_4_5005_c](https://user-images.githubusercontent.com/70232643/119745150-66fe6880-be42-11eb-8af1-d584ae2118d8.jpeg)

Fixes # (issue)
 Judge bookmark tracking with first name instead switched to judge_id.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
