### PR TITLE
fixes okta register/back button whitescreen bug

### DIFF
--- a/src/components/pages/Login/LoginContainer.js
+++ b/src/components/pages/Login/LoginContainer.js
@@ -8,34 +8,34 @@ import logo from '../../../styles/hrf-logo.png';
 
 import { config } from '../../../utils/oktaConfig';
 
+const { pkce, issuer, clientId, redirectUri, scopes } = config;
+
+const widget = new OktaSignIn({
+  baseUrl: issuer ? issuer.split('/oauth2')[0] : '',
+  clientId,
+  redirectUri,
+  registration: {},
+  features: { registration: false },
+  // turning this feature on allows your widget to use Okta for user registration
+  i18n: {
+    en: {
+      'primaryauth.title': 'Log in to Continue',
+      'primaryauth.username.placeholder': 'Email Address',
+      'password.forgot.email.or.username.placeholder': 'Email Address',
+      'password.forgot.email.or.username.tooltip': ' ',
+      // change title for your app
+    },
+  },
+  authParams: {
+    pkce,
+    issuer,
+    display: 'page',
+    scopes,
+  },
+});
+
 const LoginContainer = () => {
   useEffect(() => {
-    const { pkce, issuer, clientId, redirectUri, scopes } = config;
-
-    const widget = new OktaSignIn({
-      baseUrl: issuer ? issuer.split('/oauth2')[0] : '',
-      clientId,
-      redirectUri,
-      registration: {},
-      features: { registration: false },
-      // turning this feature on allows your widget to use Okta for user registration
-      i18n: {
-        en: {
-          'primaryauth.title': 'Log in to Continue',
-          'primaryauth.username.placeholder': 'Email Address',
-          'password.forgot.email.or.username.placeholder': 'Email Address',
-          'password.forgot.email.or.username.tooltip': ' ',
-          // change title for your app
-        },
-      },
-      authParams: {
-        pkce,
-        issuer,
-        display: 'page',
-        scopes,
-      },
-    });
-
     widget.renderEl(
       { el: '#sign-in-widget' },
       () => {
@@ -49,6 +49,10 @@ const LoginContainer = () => {
       }
     );
   }, []);
+
+  const removeOktaSignIn = () => {
+    widget.remove();
+  };
 
   return (
     <div className="login-container">
@@ -64,7 +68,11 @@ const LoginContainer = () => {
           <div id="sign-in-widget" aria-label="login form" />
           <p className="register">
             Don't have an account?{' '}
-            <Link className="link-styles" to="/signup">
+            <Link
+              className="link-styles"
+              to="/signup"
+              onClick={removeOktaSignIn}
+            >
               <span>Register here</span>
             </Link>
           </p>


### PR DESCRIPTION
## Description

There was a bug that was causing the login page to crash if the Register Link was clicked and then the browser back button was clicked to go back to the login page.

Fixes # (issue)

Moved the widget out of the useEffect() for the login page so that remove() could be called on it when the Register Link is clicked (per okta documentation)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
