### PR TITLE
fixes DOM error of inlineIndent not recognized

### DIFF
--- a/src/components/pages/SideDrawer/MenuButton.js
+++ b/src/components/pages/SideDrawer/MenuButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button } from 'antd';
+import { DoubleRightOutlined, DoubleLeftOutlined } from '@ant-design/icons';
+
+const MenuButton = ({ toggle, collapsed }) => {
+  return (
+    <Button type="primary" className="toggle-btn" onClick={toggle}>
+      {collapsed ? <DoubleRightOutlined /> : <DoubleLeftOutlined />}
+    </Button>
+  );
+};
+
+export default MenuButton;

--- a/src/components/pages/SideDrawer/SideDrawer.js
+++ b/src/components/pages/SideDrawer/SideDrawer.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Menu, Button } from 'antd';
+import { Menu } from 'antd';
 import './_SideDrawer.less';
-
-import { DoubleRightOutlined, DoubleLeftOutlined } from '@ant-design/icons';
+import MenuButton from './MenuButton';
 
 const { SubMenu } = Menu;
 
@@ -38,11 +37,7 @@ function SideDrawer() {
           position: 'sticky',
         }}
       >
-        <Button type="primary" className="toggle-btn" onClick={toggleCollapsed}>
-          {React.createElement(
-            collapsed ? DoubleRightOutlined : DoubleLeftOutlined
-          )}
-        </Button>
+        <MenuButton toggle={toggleCollapsed} collapsed={collapsed} />
 
         <Menu.Item className="home" key="/">
           Home


### PR DESCRIPTION
## Description

Getting DOM error from non-menu item in the side drawer:

React does not recognize the inlineIndent prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase inlineindent instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Fixes # (issue)

Moved the collapse button to its own component to fix DOM error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
