### PR TITLE
fixes <Link to=''> warning in browser

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -241,12 +241,7 @@ export default function CaseTable(props) {
       title: 'Case Details',
       dataIndex: 'case_row',
       key: 'x',
-      render: text => (
-        <Link onClick={() => popUpDetails(text)}>
-          {' '}
-          <FileTextOutlined />{' '}
-        </Link>
-      ),
+      render: text => <FileTextOutlined onClick={() => popUpDetails(text)} />,
     },
     {
       title: 'Case Date',
@@ -371,7 +366,7 @@ export default function CaseTable(props) {
         setSavedCases(res.data.case_bookmarks);
       })
       .catch(err => {
-        console.log(err);
+        throw new Error(err);
       });
   };
 
@@ -395,6 +390,7 @@ export default function CaseTable(props) {
 
       bookmarks.forEach(b => {
         if (savedIds.includes(b.case_id)) {
+          // This should be an alert
           console.log('Case already saved to bookmarks');
         } else {
           postBookmark(b.case_id);

--- a/src/components/pages/Cases/CaseTable.less
+++ b/src/components/pages/Cases/CaseTable.less
@@ -1,4 +1,3 @@
-
 @blue: #2a5c8d;
 
 .cases-container {
@@ -34,7 +33,6 @@
 }
 /* Chart Container Adjustments */
 
-
 .case-table-container {
   width: 100%;
   overflow-y: hidden;
@@ -54,7 +52,6 @@
 .table-search-button {
   color: white;
 }
-
 
 .ant-tabs {
   overflow: unset;
@@ -86,26 +83,28 @@
   margin-top: 0.5rem;
 }
 
+.anticon-file-text {
+  color: @blue;
+}
+
 button.ant-btn {
   color: @blue;
   font-size: 1rem;
   border: none;
   display: flex;
-  justify-content:center;
-  align-items:center;
-  box-shadow:none;
-  margin:0.5rem 0.5rem 0 0;
+  justify-content: center;
+  align-items: center;
+  box-shadow: none;
+  margin: 0.5rem 0.5rem 0 0;
 }
 
 button.ant-btn:hover {
   color: @blue;
   font-size: 1rem;
-  border:none;
+  border: none;
   display: flex;
-  justify-content:center;
-  align-items:center;
-  box-shadow:none;
-  margin:0.5rem 0.5rem 0 0;
+  justify-content: center;
+  align-items: center;
+  box-shadow: none;
+  margin: 0.5rem 0.5rem 0 0;
 }
-  
-  


### PR DESCRIPTION
## Description

Changed the Cases page table Case Details button from a Link without a destination to just use the icon as a link.

Also changed an axios catch from a console.log to throw new Error(err).

Added comment on bookmark function that it should be converted to an alert.

Fixes # (issue)

On the Cases page, the table Case Details button was producing a warning in the browser console about the <Link> component not having the required to='' completed (Link without a destination).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
