### PR TITLE
fixes unique key warnings for saved cases

### DIFF
--- a/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
+++ b/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
@@ -97,7 +97,7 @@ export function MyDoc(props) {
           </View>
           {props.caseData.map(item => {
             return (
-              <View style={styles.tableRow}>
+              <View key={item.case_id} style={styles.tableRow}>
                 <View style={styles.tableCol}>
                   <Text style={styles.tableCell}>{item.case_id}</Text>
                 </View>

--- a/src/components/pages/SavedCases/SavedCases.js
+++ b/src/components/pages/SavedCases/SavedCases.js
@@ -128,7 +128,11 @@ function SavedCases({ savedCases, setSavedCases, deleteBookmark }) {
         <p className="divider">
           <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
         </p>
-        <Table columns={columns} dataSource={savedCases} />
+        <Table
+          rowKey={record => record.case_id}
+          columns={columns}
+          dataSource={savedCases}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Added rowKey prop to the antd Table component in SavedCAses.js and added key prop to the View component caseData map in ExportGenerator.jsx

Fixes # (issue)

Getting unique key warnings in console due to antd Table rows missing keys.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
