### PR TITLE
fixes unique key warning on manage-faq page

### DIFF
--- a/src/components/pages/AdminTools/ManageFaq.js
+++ b/src/components/pages/AdminTools/ManageFaq.js
@@ -128,7 +128,11 @@ const ManageFaqPage = props => {
         <Collapse accordion>
           {faq.map(item => {
             return (
-              <Panel className="q-header" header={`${item.question}`}>
+              <Panel
+                key={item.faq_id}
+                className="q-header"
+                header={`${item.question}`}
+              >
                 <p className="answer">Answer: </p>
                 <span>{item.answer}</span>
                 <div className="buttons">


### PR DESCRIPTION
## Description

Added key prop to Panel component in ManageFaq.js

Fixes # (issue)

Getting unique key warnings in console due to FAQs missing key prop

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes