### PR TITLE
Bug/manage cases loop/rpeck

### DIFF
--- a/src/components/pages/Home/RenderHomePage.js
+++ b/src/components/pages/Home/RenderHomePage.js
@@ -232,7 +232,7 @@ function RenderHomePage(props) {
               <CaseUpdate />
             </Route>
             <Route exact path="/manage-cases">
-              <ManageCases />
+              <ManageCases authState={user.authState} />
             </Route>
             <Route exact path="/account">
               <AccountPage

--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -15,6 +15,7 @@ const { TextArea } = Input;
 //***There is a bug*** Currently, when you expand one caseObj they all expand. This may be an issue with accept and reject buttons - we don't want to accept all or reject all on accident!
 
 export default function ManageCases(props) {
+  const { authState } = props;
   const [apiData, setApiData] = useState([]);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [currentCase, setCurrentCase] = useState();
@@ -145,9 +146,8 @@ export default function ManageCases(props) {
     },
   ];
 
-  let filteredData = [];
-
   useEffect(() => {
+    let filteredData = [];
     axiosWithAuth()
       .get(`/cases/pending`)
       .then(res => {
@@ -165,7 +165,7 @@ export default function ManageCases(props) {
         console.log(err);
         //need to change functionality to render the error to the screen for user
       });
-  }, [filteredData]);
+  }, [authState.idToken.idToken]);
 
   return (
     <div className="manage-cases-container">


### PR DESCRIPTION
## Description

The ManageCases component was modified to follow the same pattern as the ManageUsers and ManageFaq components, both of which recieve authState as a prop and use the token to control the useEffect loop to load initial data. This is to prevent the useEffect in ManageCases from running in an infinite loop.

#### Context:

The useEffect function in the ManageCases component would run whenever filteredData changed, but the function itself was the only thing modifying filteredData. When the manage-cases page loaded, the useEffect would run in an infinite loop, making many GET requests to the API per second and storing the results. 

Fixes # ManageCases useEffect Loop

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
