### PR TITLE
Fixes a UI bug in the AccountPage.js component

### DIFF
--- a/src/components/pages/AccountPage/AccountPage.js
+++ b/src/components/pages/AccountPage/AccountPage.js
@@ -45,7 +45,7 @@ const AccountPage = props => {
     axiosWithAuth()
       .put(`/profile/${updatedUserInfo.user_id}`, updatedUserInfo)
       .then(res => {
-        setHrfUserInfo(updatedUserInfo);
+        setHrfUserInfo(res.data.updated_profile);
       })
       .catch(err => console.log(err));
     setFormValues(initialFormValues);
@@ -58,7 +58,6 @@ const AccountPage = props => {
       last_name: formValues.last_name.trim(),
       email: formValues.email.trim(),
       user_id: formValues.user_id.trim(),
-      role: hrfUserInfo.role
     };
     updateUser(updatedUser);
     setIsEditModalVisible(false);
@@ -95,7 +94,21 @@ const AccountPage = props => {
               </div>
               <div className="info-line">
                 <p className="p-1">Role: </p>
-                <p className="p-2">{hrfUserInfo.role_name}</p>
+                {hrfUserInfo.role_id === 1 ? (
+                  <p className="p-2">admin</p>
+                ) : (
+                  <p className="p-2"></p>
+                )}
+                {hrfUserInfo.role_id === 2 ? (
+                  <p className="p-2">moderator</p>
+                ) : (
+                  <p className="p-2"></p>
+                )}
+                {hrfUserInfo.role_id === 3 ? (
+                  <p className="p-2">user</p>
+                ) : (
+                  <p className="p-2"></p>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description

There was a bug in the AccountPage.js component which would erase the role name displayed in the UI upon editing account details (on a successful PUT request). This update fixes that error by implementing several ternary checks to determine the appropriate role name that is to be rendered - these ternary checks reflect the recent updates to the role names in the backend ('admin', 'moderator', and 'user').

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
