### PR TITLE
centered reset email btn

### DIFF
--- a/src/components/pages/Login/_LoginContainerStyled.less
+++ b/src/components/pages/Login/_LoginContainerStyled.less
@@ -157,6 +157,9 @@
         background: @button;
         height: 2.6rem;
         width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       .okta-form-input-field input {


### PR DESCRIPTION
Fixed the reset via email button text not being centered. The text is now centered.

Fixes # (issue)

Reset via email button text is now centered.

Type of change
Styling

Checklist:
[ x] My code follows the style guidelines of this project
[ x] I have performed a self-review of my own code
[x ] I have removed unnecessary comments/console logs from my code
[x ] I have made corresponding changes to the documentation if necessary (optional)
[x ] My changes generate no new warnings
[x ] I have checked my code and corrected any misspellings
[ x] No duplicate code left within changed files
[ x] Size of pull request kept to a minimum
[x ] Pull request description clearly describes changes made & motivations for said changes