### PR TITLE
Bugfix/schema alignment

### DIFF
--- a/src/components/pages/CaseOverview/CaseDetails.js
+++ b/src/components/pages/CaseOverview/CaseDetails.js
@@ -17,7 +17,7 @@ const CaseDetails = props => {
     setIsEditModalVisible(true);
   };
 
-  const theDate = new Date(caseData.date);
+  const theDate = new Date(caseData.decision_date);
   const converted = moment(theDate).format('MMMM D, Y');
 
   return (

--- a/src/components/pages/CaseOverview/CaseDetails.js
+++ b/src/components/pages/CaseOverview/CaseDetails.js
@@ -59,7 +59,7 @@ const CaseDetails = props => {
         <p>{`Protected Grounds: ${caseData.protected_grounds}`}</p>
         <p>{`Outcome: ${caseData.outcome}`}</p>
         <p>{`Country of Origin: ${caseData.country_of_origin}`}</p>
-        <p>{`Filed Within One Year: ${caseData.filed_in_one_year}`}</p>
+        <p>{`Filed Within One Year: ${caseData.check_for_one_year}`}</p>
         <p>{`Applicant Language: ${caseData.applicant_language}`}</p>
         {/* the segment below displays the disclaimer message with the details requested by the stakeholders*/}
         <br></br>

--- a/src/components/pages/CaseOverview/CaseDetails.js
+++ b/src/components/pages/CaseOverview/CaseDetails.js
@@ -54,7 +54,7 @@ const CaseDetails = props => {
         <p>{`Origin City: ${caseData.case_origin_city}`}</p>
         <p>{`Origin State: ${caseData.case_origin_state}`}</p>
         <p>{`Gender: ${caseData.gender}`}</p>
-        <p>{`Type of Violence: ${caseData.type_of_violence}`}</p>
+        <p>{`Type of Persecution: ${caseData.type_of_persecution}`}</p>
         <p>{`Indigenous Group: ${caseData.indigenous_group}`}</p>
         <p>{`Protected Grounds: ${caseData.protected_grounds}`}</p>
         <p>{`Outcome: ${caseData.outcome}`}</p>

--- a/src/components/pages/CaseOverview/CaseOverview.js
+++ b/src/components/pages/CaseOverview/CaseOverview.js
@@ -87,7 +87,7 @@ const CaseOverview = props => {
               </p>
               <p>Applicant Gender: {caseData.applicant_gender}</p>
               <p>
-                Violence Experienced: {caseData.type_of_violence_experienced}
+                Violence Experienced: {caseData.type_of_persecution_experienced}
               </p>
               <br />
               <p style={{ textDecoration: 'underline', fontWeight: 'bold' }}>

--- a/src/components/pages/CaseOverview/CaseUpdate.js
+++ b/src/components/pages/CaseOverview/CaseUpdate.js
@@ -134,8 +134,8 @@ const CaseUpdate = props => {
       </Form.Item>
 
       <Form.Item
-        label="Type of Violence Experienced"
-        name="type_of_violence_experienced"
+        label="Type of Persecution Experienced"
+        name="type_of_persecution_experienced"
       >
         <Input />
       </Form.Item>

--- a/src/components/pages/CaseOverview/EditCaseDetails.js
+++ b/src/components/pages/CaseOverview/EditCaseDetails.js
@@ -23,7 +23,7 @@ const initialFormValues = {
   type_of_persecution: '',
   indigenous_group: '',
   applicant_language: '',
-  credible: false,
+  credibility: false,
 };
 
 const EditCaseDetails = props => {
@@ -82,8 +82,8 @@ const EditCaseDetails = props => {
   };
 
   const onCheck = e => {
-    console.log(formValues.credible);
-    setFormValues({ ...formValues, credible: !e.target.checked });
+    console.log(formValues.credibility);
+    setFormValues({ ...formValues, credibility: !e.target.checked });
   };
 
   return (
@@ -230,12 +230,12 @@ const EditCaseDetails = props => {
           />
         </Form.Item>
         <Checkbox
-          id="credible"
-          name="credible"
-          value={formValues.credible}
+          id="credibility"
+          name="credibility"
+          value={formValues.credibility}
           onClick={onCheck}
         >
-          Credible
+          credibility
         </Checkbox>
       </Form>
     </Modal>

--- a/src/components/pages/CaseOverview/EditCaseDetails.js
+++ b/src/components/pages/CaseOverview/EditCaseDetails.js
@@ -235,7 +235,7 @@ const EditCaseDetails = props => {
           value={formValues.credibility}
           onClick={onCheck}
         >
-          credibility
+          Credibility
         </Checkbox>
       </Form>
     </Modal>

--- a/src/components/pages/CaseOverview/EditCaseDetails.js
+++ b/src/components/pages/CaseOverview/EditCaseDetails.js
@@ -20,7 +20,7 @@ const initialFormValues = {
   case_origin_city: '',
   case_origin_state: '',
   gender: '',
-  type_of_violence: '',
+  type_of_persecution: '',
   indigenous_group: '',
   applicant_language: '',
   credible: false,
@@ -196,15 +196,15 @@ const EditCaseDetails = props => {
             value={formValues.gender}
           />
         </Form.Item>
-        <Form.Item label="Type of Violence">
+        <Form.Item label="Type of Persecution">
           <Input
-            id="type_of_violence"
+            id="type_of_persecution"
             type="text"
-            name="type_of_violence"
-            placeholder="Type of Violence"
+            name="type_of_persecution"
+            placeholder="Type of Persecution"
             onChange={onChange}
-            className="type_of_violence"
-            value={formValues.type_of_violence}
+            className="type_of_persecution"
+            value={formValues.type_of_persecution}
           />
         </Form.Item>
         <Form.Item label="Indigenous Group">

--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -262,11 +262,11 @@ export default function CaseTable(props) {
     },
     {
       title: 'Case Date',
-      dataIndex: 'date',
-      key: 'date',
-      sorter: (a, b) => a.date.localeCompare(b.date),
+      dataIndex: 'decision_date',
+      key: 'decision_date',
+      sorter: (a, b) => a.decision_date.localeCompare(b.decision_date),
       sortDirections: ['descend', 'ascend'],
-      ...getColumnSearchProps('date'),
+      ...getColumnSearchProps('decision_date'),
       render: text => formatDate(text),
     },
     {

--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -461,7 +461,7 @@ export default function CaseTable(props) {
     type_of_persecution: '',
     indigenous_group: '',
     applicant_language: '',
-    credible: '',
+    credibility: '',
   });
 
   const filter = data => {

--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -359,11 +359,12 @@ export default function CaseTable(props) {
     },
     {
       title: 'Violence Experienced',
-      dataIndex: 'type_of_violence',
-      key: 'type_of_violence',
-      sorter: (a, b) => a.type_of_violence.localeCompare(b.type_of_violence),
+      dataIndex: 'type_of_persecution',
+      key: 'type_of_persecution',
+      sorter: (a, b) =>
+        a.type_of_persecution.localeCompare(b.type_of_persecution),
       sortDirections: ['descend', 'ascend'],
-      ...getColumnSearchProps('type_of_violence'),
+      ...getColumnSearchProps('type_of_persecution'),
     },
     {
       title: 'Applicant Language',
@@ -457,7 +458,7 @@ export default function CaseTable(props) {
     outcome: '',
     country_of_origin: '',
     gender: '',
-    type_of_violence: '',
+    type_of_persecution: '',
     indigenous_group: '',
     applicant_language: '',
     credible: '',

--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -66,10 +66,10 @@ export default function CaseTable(props) {
         : null,
 
     filed_within_year:
-      cases.filed_in_one_year
+      cases.check_for_one_year
         .toString()
         .charAt(0)
-        .toUpperCase() + cases.filed_in_one_year.toString().slice(1),
+        .toUpperCase() + cases.check_for_one_year.toString().slice(1),
     case_row: cases,
     ...cases,
   }));
@@ -452,7 +452,7 @@ export default function CaseTable(props) {
     judge: '',
     case_origin_city: '',
     case_origin_state: '',
-    filed_in_one_year: '',
+    check_for_one_year: '',
     application_type: '',
     protected_grounds: '',
     outcome: '',

--- a/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
+++ b/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
@@ -213,7 +213,7 @@ export function MyDoc(props) {
                 </View>
                 <View style={styles.tableCol}>
                   <Text style={styles.tableCell}>
-                    {convertTrueFalse(item.filed_in_one_year)}
+                    {convertTrueFalse(item.check_for_one_year)}
                   </Text>
                 </View>
                 <View style={styles.tableCol}>

--- a/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
+++ b/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
@@ -168,9 +168,7 @@ export function MyDoc(props) {
                   <Text style={styles.tableCell}>{item.gender}</Text>
                 </View>
                 <View style={styles.tableCol}>
-                  <Text style={styles.tableCell}>
-                    {item.type_of_persecution}
-                  </Text>
+                  <Text style={styles.tableCell}>{item.type_of_persecution}</Text>
                 </View>
               </View>
             );

--- a/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
+++ b/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
@@ -168,7 +168,9 @@ export function MyDoc(props) {
                   <Text style={styles.tableCell}>{item.gender}</Text>
                 </View>
                 <View style={styles.tableCol}>
-                  <Text style={styles.tableCell}>{item.type_of_violence}</Text>
+                  <Text style={styles.tableCell}>
+                    {item.type_of_persecution}
+                  </Text>
                 </View>
               </View>
             );

--- a/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
+++ b/src/components/pages/Cases/PDFOverviewExport/ExportGenerator.jsx
@@ -191,7 +191,7 @@ export function MyDoc(props) {
               <Text style={styles.columnNameCell}>Application Type</Text>
             </View>
             <View style={styles.tableCol}>
-              <Text style={styles.columnNameCell}>Credible?</Text>
+              <Text style={styles.columnNameCell}>credibility?</Text>
             </View>
             <View style={styles.tableCol}>
               <Text style={styles.columnNameCell}>Indigenous Group</Text>
@@ -226,7 +226,7 @@ export function MyDoc(props) {
                 </View>
                 <View style={styles.tableCol}>
                   <Text style={styles.tableCell}>
-                    {convertTrueFalse(item.credible)}
+                    {convertTrueFalse(item.credibility)}
                   </Text>
                 </View>
                 <View style={styles.tableCol}>

--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -214,8 +214,7 @@ export default function ManageCases(props) {
                   {caseObj.credibility ? 'True' : 'False'}
                 </p>
                 <p style={{ margin: 0 }}>
-                  Violence Experienced:{' '}
-                  {caseObj.type_of_persecution_experienced}
+                  Persecution Experienced: {caseObj.type_of_persecution_experienced}
                 </p>
               </div>
             ),

--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -210,8 +210,8 @@ export default function ManageCases(props) {
                   {caseObj.filed_within_one_year ? 'True' : 'False'}
                 </p>
                 <p style={{ margin: 0 }}>
-                  Credible:
-                  {caseObj.credible ? 'True' : 'False'}
+                  credibility:
+                  {caseObj.credibility ? 'True' : 'False'}
                 </p>
                 <p style={{ margin: 0 }}>
                   Violence Experienced:{' '}

--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -214,7 +214,8 @@ export default function ManageCases(props) {
                   {caseObj.credible ? 'True' : 'False'}
                 </p>
                 <p style={{ margin: 0 }}>
-                  Violence Experienced: {caseObj.type_of_violence_experienced}
+                  Violence Experienced:{' '}
+                  {caseObj.type_of_persecution_experienced}
                 </p>
               </div>
             ),

--- a/src/components/pages/MyCases/MyCases.js
+++ b/src/components/pages/MyCases/MyCases.js
@@ -26,7 +26,7 @@ const initialFormValues = {
   type_of_persecution: '',
   initial_or_appellate: false,
   filed_in_one_year: false,
-  credible: false,
+  credibility: false,
 };
 export default function MyCases(props) {
   const { TabPane } = Tabs;

--- a/src/components/pages/MyCases/MyCases.js
+++ b/src/components/pages/MyCases/MyCases.js
@@ -25,7 +25,7 @@ const initialFormValues = {
   indigenous_group: '',
   type_of_persecution: '',
   initial_or_appellate: false,
-  filed_in_one_year: false,
+  check_for_one_year: false,
   credibility: false,
 };
 export default function MyCases(props) {

--- a/src/components/pages/MyCases/MyCases.js
+++ b/src/components/pages/MyCases/MyCases.js
@@ -23,7 +23,7 @@ const initialFormValues = {
   gender: '',
   applicant_language: '',
   indigenous_group: '',
-  type_of_violence: '',
+  type_of_persecution: '',
   initial_or_appellate: false,
   filed_in_one_year: false,
   credible: false,

--- a/src/components/pages/MyCases/ReviewCaseForm.js
+++ b/src/components/pages/MyCases/ReviewCaseForm.js
@@ -277,7 +277,7 @@ const ReviewCaseForm = props => {
               checked={editedFormValues.check_for_one_year}
               onChange={onInputChange}
             >
-              Case was filed Within One Year
+              Case was Filed Within One Year
             </Checkbox>
           </div>
           <div className="checkbox">
@@ -286,7 +286,7 @@ const ReviewCaseForm = props => {
               checked={editedFormValues.credibility}
               onChange={onInputChange}
             >
-              Applicant is Perceived as credibility
+              Applicant is Perceived as Credible
             </Checkbox>
           </div>
           <div className="submit-button">

--- a/src/components/pages/MyCases/ReviewCaseForm.js
+++ b/src/components/pages/MyCases/ReviewCaseForm.js
@@ -20,7 +20,7 @@ const ReviewCaseForm = props => {
     console.log(formValues);
     const { name, value, checked } = e.target;
     if (
-      name === 'filed_in_one_year' ||
+      name === 'check_for_one_year' ||
       name === 'initial_or_appellate' ||
       name === 'credibility'
     ) {
@@ -63,7 +63,7 @@ const ReviewCaseForm = props => {
             indigenous_group: editedFormValues.indigenous_group,
             type_of_persecution: editedFormValues.type_of_persecution,
             initial_or_appellate: editedFormValues.initial_or_appellate,
-            filed_in_one_year: editedFormValues.filed_in_one_year,
+            check_for_one_year: editedFormValues.check_for_one_year,
             credibility: editedFormValues.credibility,
           }}
         >
@@ -273,8 +273,8 @@ const ReviewCaseForm = props => {
           </div>
           <div className="checkbox">
             <Checkbox
-              name="filed_in_one_year"
-              checked={editedFormValues.filed_in_one_year}
+              name="check_for_one_year"
+              checked={editedFormValues.check_for_one_year}
               onChange={onInputChange}
             >
               Case was filed Within One Year

--- a/src/components/pages/MyCases/ReviewCaseForm.js
+++ b/src/components/pages/MyCases/ReviewCaseForm.js
@@ -61,7 +61,7 @@ const ReviewCaseForm = props => {
             case_origin_state: editedFormValues.case_origin_state,
             gender: editedFormValues.gender,
             indigenous_group: editedFormValues.indigenous_group,
-            type_of_violence: editedFormValues.type_of_violence,
+            type_of_persecution: editedFormValues.type_of_persecution,
             initial_or_appellate: editedFormValues.initial_or_appellate,
             filed_in_one_year: editedFormValues.filed_in_one_year,
             credible: editedFormValues.credible,
@@ -245,17 +245,17 @@ const ReviewCaseForm = props => {
           </div>
           <div className="type-of-violence-experienced">
             <Form.Item
-              label="Type of Violence Experienced"
+              label="Type of Persecution Experienced"
               id="type-of-violence-experienced"
               type="text"
-              name="type_of_violence"
+              name="type_of_persecution"
               onChange={onInputChange}
-              placeholder="Type of Violence Experienced"
-              value={editedFormValues.type_of_violence}
+              placeholder="Type of Persecution Experienced"
+              value={editedFormValues.type_of_persecution}
               rules={[
                 {
                   required: true,
-                  message: 'Please input Type of Violence Experienced',
+                  message: 'Please input Type of Persecution Experienced',
                 },
               ]}
             >

--- a/src/components/pages/MyCases/ReviewCaseForm.js
+++ b/src/components/pages/MyCases/ReviewCaseForm.js
@@ -22,7 +22,7 @@ const ReviewCaseForm = props => {
     if (
       name === 'filed_in_one_year' ||
       name === 'initial_or_appellate' ||
-      name === 'credible'
+      name === 'credibility'
     ) {
       setEditedFormValues({ ...editedFormValues, [name]: checked });
     } else {
@@ -64,7 +64,7 @@ const ReviewCaseForm = props => {
             type_of_persecution: editedFormValues.type_of_persecution,
             initial_or_appellate: editedFormValues.initial_or_appellate,
             filed_in_one_year: editedFormValues.filed_in_one_year,
-            credible: editedFormValues.credible,
+            credibility: editedFormValues.credibility,
           }}
         >
           <div>
@@ -282,11 +282,11 @@ const ReviewCaseForm = props => {
           </div>
           <div className="checkbox">
             <Checkbox
-              name="credible"
-              checked={editedFormValues.credible}
+              name="credibility"
+              checked={editedFormValues.credibility}
               onChange={onInputChange}
             >
-              Applicant is Perceived as Credible
+              Applicant is Perceived as credibility
             </Checkbox>
           </div>
           <div className="submit-button">

--- a/src/components/pages/SavedCases/SavedCases.js
+++ b/src/components/pages/SavedCases/SavedCases.js
@@ -81,7 +81,7 @@ function SavedCases({ savedCases, setSavedCases, deleteBookmark }) {
               case_origin_city: record.case_origin_city,
               case_origin_state: record.case_origin_state,
               country_of_origin: record.country_of_origin,
-              credible: record.credible,
+              credibility: record.credibility,
               date: record.date,
               filed_in_one_year: record.filed_in_one_year,
               first_name: record.first_name,

--- a/src/components/pages/SavedCases/SavedCases.js
+++ b/src/components/pages/SavedCases/SavedCases.js
@@ -94,7 +94,7 @@ function SavedCases({ savedCases, setSavedCases, deleteBookmark }) {
               outcome: record.outcome,
               protected_grounds: record.protected_grounds,
               status: record.status,
-              type_of_violence: record.type_of_violence,
+              type_of_persecution: record.type_of_persecution,
               url: record.url,
             },
           ]} /*viz={}*/

--- a/src/components/pages/SavedCases/SavedCases.js
+++ b/src/components/pages/SavedCases/SavedCases.js
@@ -83,7 +83,7 @@ function SavedCases({ savedCases, setSavedCases, deleteBookmark }) {
               country_of_origin: record.country_of_origin,
               credibility: record.credibility,
               date: record.date,
-              filed_in_one_year: record.filed_in_one_year,
+              check_for_one_year: record.check_for_one_year,
               first_name: record.first_name,
               gender: record.gender,
               indigenous_group: record.indigenous_group,


### PR DESCRIPTION

https://user-images.githubusercontent.com/75971516/132415392-30583b2b-c149-41ff-a166-c9c011dc7c5f.mp4

## Description

**See corresponding bugfix/schema-alignment pull request in backend**

We aligned schema variable names from the data science database to the frontend. The schema names were as follows:

- date to decision_date
- type_of_violence to type_of_persecution
- credible to credibility
- filed_in_one_year to check_for_one_year

This was done to ensure that the web backend and data science backend could be swapped out with ease.

[Trello Card](https://trello.com/c/UbRXBqZ5)

Contributors to this pull request:
@ZacharyCooremans @jenna-anderson @schandrupatla @TrevorDewalt 

Fixes # (issue)

This fix allows the frontend to work with either database through having consistent variable names.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
