### PR TITLE
Feature/orange dividers

### DIFF
--- a/src/components/pages/AccountPage/AccountPage.js
+++ b/src/components/pages/AccountPage/AccountPage.js
@@ -3,8 +3,6 @@ import { Button, Card, Avatar, Modal, Form, Input } from 'antd';
 import axiosWithAuth from '../../../utils/axiosWithAuth';
 
 import './_AccountPageStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 
 const initialFormValues = {
   first_name: '',
@@ -68,10 +66,7 @@ const AccountPage = props => {
     <div className="account-container">
       <div className="account-card">
         <h2 className="faq-header">My Account </h2>
-        <p className="divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
-
+        <div className="account-divider" />
         <Card
           title={`${hrfUserInfo.first_name} ${hrfUserInfo.last_name}`}
           className="card"
@@ -145,13 +140,7 @@ const AccountPage = props => {
                 onFinish={onEditSubmit}
               >
                 <h2 className="h1Styles">Edit User</h2>
-                <p className="divider">
-                  <Icon
-                    component={() => (
-                      <img src={OrangeLine} alt="divider icon" />
-                    )}
-                  />
-                </p>
+                <div className="divider" />
                 <Form.Item label="First Name">
                   <Input
                     id="first_name"

--- a/src/components/pages/AccountPage/_AccountPageStyles.less
+++ b/src/components/pages/AccountPage/_AccountPageStyles.less
@@ -11,6 +11,13 @@
   margin-right: 3rem;
 }
 
+.account-divider {
+  border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 15px;
+  margin-bottom: 15px;
+}
+
 .account-card {
   width: 80%;
   border: none;
@@ -62,7 +69,7 @@
     background: @blue;
     color: @white;
   }
-  
+
   &:focus {
     background: @blue;
     color: @white;

--- a/src/components/pages/AdminTools/AddFaq.js
+++ b/src/components/pages/AdminTools/AddFaq.js
@@ -4,9 +4,6 @@ import { Form, Input, Button, Modal } from 'antd';
 
 import './_AddFaqStyles.less';
 
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
-
 const initialFormValues = {
   question: '',
   answer: '',
@@ -76,11 +73,7 @@ const AddFaq = () => {
         >
           <Form layout="vertical" className="faq-form" onFinish={onSubmit}>
             <h2 className="h1Styles">Add a FAQ</h2>
-            <p className="divider">
-              <Icon
-                component={() => <img src={OrangeLine} alt="divider icon" />}
-              />
-            </p>
+            <div className="divider" />
             <Form.Item label="Question">
               <Input
                 id="question"

--- a/src/components/pages/AdminTools/ManageFaq.js
+++ b/src/components/pages/AdminTools/ManageFaq.js
@@ -13,8 +13,6 @@ import {
 import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
 import './_AddFaqStyles.less';
 import './_ManageFaqStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 
 const initialFormValues = {
   question: '',
@@ -122,9 +120,7 @@ const ManageFaqPage = props => {
     <div className="manage-faq-container">
       <div className="faq">
         <h2 className="faq-header"> Manage FAQ </h2>
-        <p className="divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
+        <div className="faq-divider" />
         <Collapse accordion>
           {faq.map(item => {
             return (
@@ -176,11 +172,7 @@ const ManageFaqPage = props => {
         >
           <Form layout="vertical" className="faq-form" onFinish={onSubmit}>
             <h2 className="h1Styles">Add a FAQ</h2>
-            <p className="divider">
-              <Icon
-                component={() => <img src={OrangeLine} alt="divider icon" />}
-              />
-            </p>
+            <div className="divider" />
             <Form.Item label="Question">
               <Input
                 id="question"

--- a/src/components/pages/AdminTools/ManageUsers.js
+++ b/src/components/pages/AdminTools/ManageUsers.js
@@ -232,7 +232,7 @@ const ManageUsersPage = props => {
           >
             <Form layout="vertical" className="user-form" onFinish={onSubmit}>
               <h2 className="h1Styles">Edit User</h2>
-              <p className="divider" />
+              <div className="divider" />
               <Form.Item label="First Name">
                 <Input
                   id="first_name"
@@ -308,7 +308,7 @@ const ManageUsersPage = props => {
         >
           <Form layout="vertical" className="user-form" onFinish={onSubmit}>
             <h2 className="h1Styles">Add a User</h2>
-            <p className="divider" />
+            <div className="divider" />
             <Form.Item label="First Name">
               <Input
                 id="first_name"

--- a/src/components/pages/AdminTools/ManageUsers.js
+++ b/src/components/pages/AdminTools/ManageUsers.js
@@ -206,9 +206,9 @@ const ManageUsersPage = props => {
     <div className="users-container">
       <div className="users">
         <h2 className="users-header"> Manage Users </h2>
-        <p className="divider">
+        <div className="users-divider">
           <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
+        </div>
       </div>
       <Tabs defaultActiveKey="1">
         <TabPane tab="Manage Users" key="1">

--- a/src/components/pages/AdminTools/ManageUsers.js
+++ b/src/components/pages/AdminTools/ManageUsers.js
@@ -13,8 +13,6 @@ import PendingUsers from './PendingUsers';
 
 // Styling and Icons
 import './_ManageUsersStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 
 const initialFormValues = {
   first_name: '',
@@ -234,11 +232,7 @@ const ManageUsersPage = props => {
           >
             <Form layout="vertical" className="user-form" onFinish={onSubmit}>
               <h2 className="h1Styles">Edit User</h2>
-              <p className="divider">
-                <Icon
-                  component={() => <img src={OrangeLine} alt="divider icon" />}
-                />
-              </p>
+              <p className="divider" />
               <Form.Item label="First Name">
                 <Input
                   id="first_name"
@@ -314,11 +308,7 @@ const ManageUsersPage = props => {
         >
           <Form layout="vertical" className="user-form" onFinish={onSubmit}>
             <h2 className="h1Styles">Add a User</h2>
-            <p className="divider">
-              <Icon
-                component={() => <img src={OrangeLine} alt="divider icon" />}
-              />
-            </p>
+            <p className="divider" />
             <Form.Item label="First Name">
               <Input
                 id="first_name"

--- a/src/components/pages/AdminTools/ManageUsers.js
+++ b/src/components/pages/AdminTools/ManageUsers.js
@@ -206,9 +206,7 @@ const ManageUsersPage = props => {
     <div className="users-container">
       <div className="users">
         <h2 className="users-header"> Manage Users </h2>
-        <div className="users-divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </div>
+        <div className="users-divider" />
       </div>
       <Tabs defaultActiveKey="1">
         <TabPane tab="Manage Users" key="1">

--- a/src/components/pages/AdminTools/_ManageFaqStyles.less
+++ b/src/components/pages/AdminTools/_ManageFaqStyles.less
@@ -12,6 +12,13 @@
   margin-right: 3rem;
 }
 
+.faq-divider {
+  border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 15px;
+  margin-bottom: 15px;
+}
+
 .faq {
   width: 80%;
   margin-bottom: 1rem;
@@ -45,7 +52,7 @@
     background: @blue;
     color: @white;
   }
-  
+
   &:hover {
     background: @light-blue;
     color: @white;

--- a/src/components/pages/AdminTools/_ManageUsersStyles.less
+++ b/src/components/pages/AdminTools/_ManageUsersStyles.less
@@ -3,8 +3,10 @@
 @light-blue: #a0c5dd;
 @white: #ffffff;
 
-.divider {
+.users-divider {
   border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 15px;
 }
 
 .users-container {

--- a/src/components/pages/AdminTools/_ManageUsersStyles.less
+++ b/src/components/pages/AdminTools/_ManageUsersStyles.less
@@ -9,6 +9,13 @@
   height: 15px;
 }
 
+.divider {
+  border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 10px;
+  margin-bottom: 15px;
+}
+
 .users-container {
   margin-left: 15rem;
   margin-right: 3rem;

--- a/src/components/pages/AdminTools/_ManageUsersStyles.less
+++ b/src/components/pages/AdminTools/_ManageUsersStyles.less
@@ -3,6 +3,10 @@
 @light-blue: #a0c5dd;
 @white: #ffffff;
 
+.divider {
+  border-bottom: 1px solid #ff7f0e;
+}
+
 .users-container {
   margin-left: 15rem;
   margin-right: 3rem;
@@ -33,12 +37,12 @@
   margin-left: 2rem;
 }
 
-.add-user-btn-container{
+.add-user-btn-container {
   display: flex;
   justify-content: center;
   align-items: center;
 }
-.add-user{
+.add-user {
   background: @blue !important;
   color: @white !important;
   margin-left: 50%;
@@ -62,7 +66,7 @@
     background: @blue;
     color: @white;
   }
-  
+
   &:focus {
     background: @blue;
     color: @white;

--- a/src/components/pages/CaseOverview/CaseDetails.js
+++ b/src/components/pages/CaseOverview/CaseDetails.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Button as AntDButton, Modal } from 'antd';
 import '../AdminTools/_ManageUsersStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 import EditCaseDetails from '../CaseOverview/EditCaseDetails';
 import moment from 'moment';
 
@@ -45,9 +43,7 @@ const CaseDetails = props => {
       ]}
     >
       <h2 className="h1Styles">Case Details</h2>
-      <p className="divider">
-        <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-      </p>
+      <div className="divider" />
       <div>
         <p>{`Case Date: ${converted}`}</p>
         <p>{`Judge Name: ${caseData.first_name} ${caseData.middle_initial}. ${caseData.last_name}`}</p>

--- a/src/components/pages/CaseOverview/EditCaseDetails.js
+++ b/src/components/pages/CaseOverview/EditCaseDetails.js
@@ -8,8 +8,6 @@ import {
   Checkbox,
 } from 'antd';
 import '../AdminTools/_ManageUsersStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 import axiosWithAuth from '../../../utils/axiosWithAuth';
 const initialFormValues = {
   date: '',
@@ -106,9 +104,7 @@ const EditCaseDetails = props => {
     >
       <Form layout="vertical" className="user-form" onFinish={onEditSubmit}>
         <h2 className="h1Styles">Edit Case Details</h2>
-        <p className="divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
+        <div className="divider" />
         <Form.Item label="Case Date">
           <Input
             id="date"

--- a/src/components/pages/JudgeTable/JudgeTable.js
+++ b/src/components/pages/JudgeTable/JudgeTable.js
@@ -296,6 +296,7 @@ export default function JudgeTable(props) {
   return (
     <div className="judge-container">
       <h2 className="h1Styles">Judges</h2>
+      <div className="judge-table-divider" />
       <div className="judge-table-container">
         <Tabs defaultActiveKey="1">
           <TabPane tab="Judges" key="1">

--- a/src/components/pages/JudgeTable/_JudgeTableStyles.less
+++ b/src/components/pages/JudgeTable/_JudgeTableStyles.less
@@ -13,7 +13,12 @@
     padding: 2%;
     margin-top: 2rem;
   }
+}
 
+.judge-table-divider {
+  border-top: 1px solid #ff7f0e;
+  width: 75%;
+  margin: auto;
 }
 
 .judge-table-container {
@@ -23,7 +28,7 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid #ff7f0e;
+  //   border-top: 1px solid #ff7f0e;
 }
 
 .save-judge-btn {
@@ -38,7 +43,7 @@
 
 .ant-tabs-tab {
   font-size: 1.2rem;
-  
+
   &.ant-tabs-tab-active .ant-tabs-tab-btn {
     text-shadow: none;
   }

--- a/src/components/pages/JudgeTable/_JudgeTableStyles.less
+++ b/src/components/pages/JudgeTable/_JudgeTableStyles.less
@@ -28,7 +28,6 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  //   border-top: 1px solid #ff7f0e;
 }
 
 .save-judge-btn {

--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -8,8 +8,6 @@ import {
   CheckCircleOutlined,
   CloseCircleOutlined,
 } from '@ant-design/icons';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 const { TextArea } = Input;
 
 //***There is a bug*** Currently, when you expand one caseObj they all expand. This may be an issue with accept and reject buttons - we don't want to accept all or reject all on accident!
@@ -167,9 +165,7 @@ export default function ManageCases(props) {
     <div className="manage-cases-container">
       <div className="manage-cases">
         <h2 className="manage-cases-title">Review Cases</h2>
-        <p className="divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
+        <div className="manage-cases-divider" />
         <Table
           columns={columns}
           dataSource={apiData[0]}

--- a/src/components/pages/ManageCases/_ManageCasesStyles.less
+++ b/src/components/pages/ManageCases/_ManageCasesStyles.less
@@ -12,6 +12,13 @@
   margin-right: 3rem;
 }
 
+.manage-cases-divider {
+  border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 15px;
+  margin-bottom: 15px;
+}
+
 .manage-cases {
   width: 90%;
 }

--- a/src/components/pages/SupportPage/SupportPage.js
+++ b/src/components/pages/SupportPage/SupportPage.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import axiosWithAuth from '../../../utils/axiosWithAuth';
 import { Collapse, Input, Button, Modal, notification, Form } from 'antd';
 import './_SupportPageStyles.less';
-import Icon from '@ant-design/icons';
-import OrangeLine from '../../../styles/orange-line.svg';
 import { CheckCircleOutlined } from '@ant-design/icons';
 const initialFormValues = {
   message: '',
@@ -122,11 +120,7 @@ const SupportPage = props => {
         >
           <Form layout="vertical" className="contact-form" onFinish={onSubmit}>
             <h2 className="h1Styles">Contact Us</h2>
-            <p className="divider">
-              <Icon
-                component={() => <img src={OrangeLine} alt="divider icon" />}
-              />
-            </p>
+            <div className="divider" />
             <Form.Item name="message" label="Message">
               <Input.TextArea
                 onChange={onChange}

--- a/src/components/pages/SupportPage/SupportPage.js
+++ b/src/components/pages/SupportPage/SupportPage.js
@@ -83,9 +83,7 @@ const SupportPage = props => {
     <div className="support-container">
       <div className="faqs">
         <h2 className="support-title">Support</h2>
-        <p className="divider">
-          <Icon component={() => <img src={OrangeLine} alt="divider icon" />} />
-        </p>
+        <div className="support-divider" />
         <h2 className="faq-title"> FAQ </h2>
         <Collapse accordion>
           {FAQ.map(item => {

--- a/src/components/pages/SupportPage/_SupportPageStyles.less
+++ b/src/components/pages/SupportPage/_SupportPageStyles.less
@@ -11,6 +11,13 @@
   margin-right: 3rem;
 }
 
+.support-divider {
+  border-bottom: 1px solid #ff7f0e;
+  width: 200px;
+  height: 15px;
+  margin-bottom: 15px;
+}
+
 .faqs {
   width: 80%;
 }
@@ -61,7 +68,7 @@
     background: @blue;
     color: @white;
   }
-  
+
   &:focus {
     background: @blue;
     color: @white;

--- a/src/components/pages/Upload/UploadCase.js
+++ b/src/components/pages/Upload/UploadCase.js
@@ -116,7 +116,7 @@ const UploadCase = ({ getPendingCases }) => {
           <div className="pdf-container">
             <div>
               <h1 className="uploadh1">Upload Cases</h1>
-              <p className="divider"></p>
+              <div className="divider" />
             </div>
             <div className="pdfUpload">
               <h2 className="h2Styles">

--- a/src/components/pages/Upload/_UploadCase.less
+++ b/src/components/pages/Upload/_UploadCase.less
@@ -5,7 +5,7 @@
 
 .uploadPage {
   display: flex;
-  padding-top: .4%;
+  padding-top: 0.4%;
   margin: 0 auto;
   width: 100%;
   justify-content: flex-end;
@@ -19,7 +19,6 @@
 
 .uploadh1 {
   font-size: 2rem;
-  border-bottom: 1px solid #ff7f0e;
 }
 
 .h2Styles {
@@ -71,7 +70,7 @@
 .review-btn {
   background: @blue;
   color: @white !important;
-  
+
   &:hover {
     background-color: @light-blue;
   }


### PR DESCRIPTION
## Description

[Loom Video](https://www.loom.com/share/d29a59a59ecf4d458d99b08da08226e4)

This branch was originally to update the orange dividers in the Admin Tools section to match the orange dividers throughout the rest of the page. However, once I began working on it, I noticed that there were other sections of the website that needed the revised dividers so I changed the scope of the branch to encompass the entire site.

For reference, the old dividers were an image of a solid orange bar, whereas the new dividers are created through CSS.

This revision helps to address the "Product Polish" MVP goal and works towards implementing uniformity in style across the site.

[Trello card](https://trello.com/c/hnvoMGpG)

Fixes # (issue)

Updates old image-based dividers with CSS-based dividers throughout the site. The now unnecessary imports (of the image and ant design icon component) have also been removed from the corresponding pages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes