### PR TITLE
Change "Filters" to "save" on judge + cases table

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -344,7 +344,7 @@ export default function CaseTable(props) {
         <Tabs defaultActiveKey="1" className="tabs">
           <TabPane tab="Initial Cases" key="1">
             <div>
-              Filters:
+              Save:
               {processFilters(initialFilters).map(filter => {
                 // console.log('EACH FILTER ', filter.value[0]);
                 return filter.value[0].split(',').map(eachKeyWord => {

--- a/src/components/pages/JudgeTable/JudgeTable.js
+++ b/src/components/pages/JudgeTable/JudgeTable.js
@@ -241,7 +241,7 @@ export default function JudgeTable(props) {
         <Tabs defaultActiveKey="1">
           <TabPane tab="Judges" key="1">
             <div>
-              Filters:{' '}
+              Save:{' '}
               {processFilters(filters).map(filter => (
                 <Tag key={filter}>{filter}</Tag>
               ))}


### PR DESCRIPTION
## Description

Changed "filters" to "save" in the judge and cases tables.

Fixes # 

Makes it more clear that when checking the boxes you are trying to save the judge or case versus trying to filter through them.

[Trello](https://trello.com/c/eBwSU8Tf/139-the-filter-option-on-cases-and-judges-page-needs-to-be-changed-to-save)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
