### PR TITLE
Styling of Login Page to Accommodate all screen sizes down to 320px

### DIFF
--- a/src/components/pages/Login/_LoginContainerStyled.less
+++ b/src/components/pages/Login/_LoginContainerStyled.less
@@ -105,10 +105,6 @@
     width: 80%;
   }
 
-  @media (max-width: 425px) {
-    width: 80%;
-  }
-
   @media (max-width: 322px) {
     .register {
       font-size: 0.9rem;

--- a/src/components/pages/Login/_LoginContainerStyled.less
+++ b/src/components/pages/Login/_LoginContainerStyled.less
@@ -98,7 +98,22 @@
   }
 
   @media (max-width: 535px) {
+    width: 60%; //80 --> 60%
+  }
+
+  @media (max-width: 450px) {
     width: 80%;
+  }
+
+  @media (max-width: 425px) {
+    width: 80%;
+  }
+
+  @media (max-width: 322px) {
+    .register {
+      font-size: 0.9rem;
+      text-align: center;
+    }
   }
 
   .logo {
@@ -122,6 +137,10 @@
     align-items: center;
     justify-content: center;
     margin: 0 auto;
+
+    @media (max-width: 500px) {
+      width: 100%;
+    }
     
     .link-styles {
       font-family: @font;
@@ -133,6 +152,16 @@
     display: flex;
     align-items: center;
     font-family: @font;
+    @media(max-width: 426px){
+      .auth-content {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 75%;
+        padding: 0;
+        margin: 0;
+      }
+    }
 
     #okta-sign-in {
       border-radius: 0.3rem;

--- a/src/components/pages/Login/_LoginContainerStyled.less
+++ b/src/components/pages/Login/_LoginContainerStyled.less
@@ -98,7 +98,7 @@
   }
 
   @media (max-width: 535px) {
-    width: 60%; //80 --> 60%
+    width: 60%;
   }
 
   @media (max-width: 450px) {
@@ -152,6 +152,7 @@
     display: flex;
     align-items: center;
     font-family: @font;
+    
     @media(max-width: 426px){
       .auth-content {
         display: flex;


### PR DESCRIPTION
Co-authored-by: Secoya Wood <zionywood@outlook.com>
Co-authored-by: Dylan Rinella <rinelladylan@aim.com>

## Description

The login page needed to be adjusted to be responsive at all screen sizes. We did some short research to find out that 320px is the smallest screen size relevant to the industry standard. It is essential for this app to accessible on a mobile phone or tablet, and this ensures in the future that the layout of the login page is polished for those experiences. In order to solve this problem, we had to identify the different components and css classes needed to adequately display the login page on all relevant screen sizes.

[Trello Card](https://trello.com/c/vSOKNvFd)
[Loom](https://www.loom.com/share/c03ba73fd4bf4852b088bff4f9ea338b)

Fixes # (issue)

Makes the login page responsive at all relevant screen sizes, down to 320px

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
