### PR TITLE
Fixed county and judge location to show up on the saved Judges and Ju…

### DIFF
--- a/src/components/pages/SavedJudges/SavedJudges.js
+++ b/src/components/pages/SavedJudges/SavedJudges.js
@@ -25,8 +25,8 @@ function SavedJudges({ savedJudges, deleteSavedJudge }) {
     },
     {
       title: 'Court Location',
-      dataIndex: 'judge_county',
-      key: 'judge_county',
+      dataIndex: 'county',
+      key: 'county',
       width: '20%',
     },
     {

--- a/src/utils/judge_utils/judge_columns.js
+++ b/src/utils/judge_utils/judge_columns.js
@@ -16,11 +16,11 @@ export function judge_columns(Link, getColumnSearchProps) {
     },
     {
       title: 'Judge County',
-      dataIndex: 'judge_county',
-      key: 'judge_county',
-      sorter: (a, b) => a.judge_county.localeCompare(b.judge_county),
+      dataIndex: 'county',
+      key: 'county',
+      sorter: (a, b) => a.county.localeCompare(b.county),
       sortDirections: ['descend', 'ascend'],
-      ...getColumnSearchProps('judge_county'),
+      ...getColumnSearchProps('county'),
     },
     {
       title: 'Date Appointed',


### PR DESCRIPTION
## Description

Fixed functionality to show judge county in both Judge Table and Saved Judges. Previously was judge_county - changed to county. The Judge county now shows on the page.

Co-authored-by: Sridevi Chandrupatla <sriluanil@gmail.com>

(url) [https://trello.com/c/0YQ6Dtqy]

(url) [https://www.loom.com/share/2dc88751eb1842aaaae5eacd944d79dd?sharedAppSource=personal_library]


Fixes # (issue) Judge county not showing on pages, changed column name to match with database.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
