### PR TITLE
replaced bookmark icon with a save button and changed "filter" to "save" in the search model

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -9,8 +9,6 @@ import {
   CloseCircleOutlined,
   CheckCircleOutlined,
 } from '@ant-design/icons';
-// import Save from '../../../styles/icons/save.svg';
-// import Icon from '@ant-design/icons';
 
 import {
   Table,
@@ -394,7 +392,6 @@ export default function CaseTable(props) {
                 }}
               >
                 Save
-                {/* <Icon component={() => <img src={Save} alt="save icon" />} /> */}
               </Button>
             }
             disabled

--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -9,8 +9,8 @@ import {
   CloseCircleOutlined,
   CheckCircleOutlined,
 } from '@ant-design/icons';
-import Save from '../../../styles/icons/save.svg';
-import Icon from '@ant-design/icons';
+// import Save from '../../../styles/icons/save.svg';
+// import Icon from '@ant-design/icons';
 
 import {
   Table,
@@ -47,6 +47,7 @@ export default function CaseTable(props) {
     searchText: '',
     searchedColumn: '',
     selectedRowID: [],
+    isDisabled: true,
   });
 
   const [isDetailsVisible, setIsDetailsVisible] = useState(false);
@@ -107,10 +108,13 @@ export default function CaseTable(props) {
 
   const { TabPane } = Tabs;
 
-  const { searchText, searchedColumn, selectedRowID } = state;
+  const { searchText, searchedColumn, selectedRowID, isDisabled } = state;
 
   const onSelectChange = selectedRowID => {
     setState({ selectedRowID });
+    selectedRowID.length > 0
+      ? setState({ isDisabled: false })
+      : setState({ isDisabled: true });
   };
 
   // Removes search tag by taking in a new value of search string
@@ -186,7 +190,7 @@ export default function CaseTable(props) {
               });
             }}
           >
-            Filter
+            Save
           </Button>
         </Space>
       </div>
@@ -384,11 +388,13 @@ export default function CaseTable(props) {
             tab={
               <Button
                 className="save-cases-btn"
+                disabled={isDisabled}
                 onClick={() => {
                   bookmarkCases(selectedRowID);
                 }}
               >
-                <Icon component={() => <img src={Save} alt="save icon" />} />
+                Save
+                {/* <Icon component={() => <img src={Save} alt="save icon" />} /> */}
               </Button>
             }
             disabled

--- a/src/components/pages/JudgeTable/JudgeTable.js
+++ b/src/components/pages/JudgeTable/JudgeTable.js
@@ -9,8 +9,6 @@ import {
 } from '@ant-design/icons';
 import { Table, Space, Button, Input, Tabs, notification, Tag } from 'antd';
 import './_JudgeTableStyles.less';
-import Save from '../../../styles/icons/save.svg';
-import Icon from '@ant-design/icons';
 
 // Column utils imports
 import { judge_columns } from '../../../utils/judge_utils/judge_columns';
@@ -21,9 +19,10 @@ export default function JudgeTable(props) {
     searchText: '',
     searchedColumn: '',
     selectedRowID: [],
+    isDisabled: true,
   });
 
-  const { searchText, searchedColumn, selectedRowID } = state;
+  const { searchText, searchedColumn, selectedRowID, isDisabled } = state;
 
   let judgesData = judgeData.map(judges => ({
     judge_name:
@@ -41,6 +40,9 @@ export default function JudgeTable(props) {
   const onSelectChange = selectedRowID => {
     console.log('selectedRowID changed: ', selectedRowID);
     setState({ selectedRowID });
+    selectedRowID.length > 0
+      ? setState({ isDisabled: false })
+      : setState({ isDisabled: true });
   };
 
   const getColumnSearchProps = dataIndex => ({
@@ -89,7 +91,7 @@ export default function JudgeTable(props) {
               });
             }}
           >
-            Filter
+            Save
           </Button>
         </Space>
       </div>
@@ -262,11 +264,12 @@ export default function JudgeTable(props) {
             tab={
               <Button
                 className="save-cases-btn"
+                disabled={isDisabled}
                 onClick={() => {
                   bookmarkJudges(selectedRowID);
                 }}
               >
-                <Icon component={() => <img src={Save} alt="save icon" />} />
+                Save
               </Button>
             }
             disabled

--- a/src/components/pages/JudgeTable/_JudgeTableStyles.less
+++ b/src/components/pages/JudgeTable/_JudgeTableStyles.less
@@ -83,3 +83,10 @@ button.ant-btn:hover {
   align-items: center;
   margin: 0.5rem 0.5rem 0 0;
 }
+
+button.save-cases-btn {
+  color: white;
+  background-color: @blue;
+  padding-bottom: .7rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Description

This started as a ticket having us change the word "filter" to "save" in the search model. It then came up that it was not very intuitive to save a judge or case with the bookmark icon.

[Trello](https://trello.com/c/eBwSU8Tf)
[Loom](https://www.loom.com/share/ebd846e9205e4b48817f81c073a81304)

Fixes # (issue)

The first fix was changing "filter" to "save" in the search model.
The second fix was to change the bookmark icon into a save button. In order to make it a little more intuitive, I disabled the button when nothing is checked, then when you check a box the button will become enabled and change from a light grey to blue using a ternary and adding another slice of state.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
