### PR TITLE
fixed box-shadow around custom-checkbox div

### DIFF
--- a/src/components/pages/Login/_LoginContainerStyled.less
+++ b/src/components/pages/Login/_LoginContainerStyled.less
@@ -197,6 +197,7 @@
       .custom-checkbox {
         margin-top: -1rem;
         padding-bottom: 1rem;
+        box-shadow: none; //This prevents the blue shadow from appearing around the entire div
       }
 
     }


### PR DESCRIPTION
## Description

On the login page the custom checkbox was getting a box-shadow border around the container it was in and the source was relatively tricky to track down but it eventually was found and the code we added although simple fixed the problem we were having. 

[Loom](https://www.loom.com/share/82e7c7b922d4496eaa483e04f4e8fd32)

-Contributors-
@ctscofield 
@RickyKlusmeier 
@willmoon19 
@lucaschatham 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [y] My code follows the style guidelines of this project
- [y] I have performed a self-review of my own code
- [y] I have removed unnecessary comments/console logs from my code
- [y] My changes generate no new warnings
- [y] I have checked my code and corrected any misspellings
- [y] No duplicate code left within changed files
- [y] Size of pull request kept to a minimum
- [y] Pull request description clearly describes changes made & motivations for said changes
