### PR TITLE
added code on line 170 to resolve bug where all cases would expand when you clicked on the expand button

### DIFF
--- a/src/components/pages/ManageCases/ManageCases.js
+++ b/src/components/pages/ManageCases/ManageCases.js
@@ -10,8 +10,6 @@ import {
 } from '@ant-design/icons';
 const { TextArea } = Input;
 
-//***There is a bug*** Currently, when you expand one caseObj they all expand. This may be an issue with accept and reject buttons - we don't want to accept all or reject all on accident!
-//
 export default function ManageCases(props) {
   const { authState } = props;
   const [apiData, setApiData] = useState([]);
@@ -169,6 +167,7 @@ export default function ManageCases(props) {
         <Table
           columns={columns}
           dataSource={apiData[0]}
+          rowKey={currentCase => currentCase.case_id}
           expandable={{
             expandedRowRender: caseObj => (
               <div key={caseObj.case_id}>


### PR DESCRIPTION
## Description

Added a rowKey on line 170 to resolve bug where all cases to review would expand or close when you click on the expand button. The rowKey filters the cases based on the current cases id. This makes it so the case you click on is the only case that will expand to show more details. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

https://www.loom.com/share/cd2a31e1a78644729f39c6f573a862d9