### PR TITLE
Added animated arrow to indicate horizontal scroll on cases page

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -333,6 +333,7 @@ export default function CaseTable(props) {
       <div className="case-table-container">
         <Tabs defaultActiveKey="1" className="tabs">
           <TabPane tab="Initial Cases" key="1">
+            <div className="arrow"></div>
             <div className="filterGallery">
               Filters:
               {processFilters(initialFilters).map(filter => {

--- a/src/components/pages/Cases/CaseTable.less
+++ b/src/components/pages/Cases/CaseTable.less
@@ -43,6 +43,7 @@
   margin: 0 0 2rem 10rem;
   padding: 1rem;
   display: flex;
+  position: relative;
 }
 
 .save-cases-btn {
@@ -109,4 +110,66 @@ button.ant-btn:hover {
   justify-content: center;
   align-items: center;
   margin: 0.5rem 0.5rem 0 0;
+}
+
+//horizontal-arrow-scroll indicator
+.arrow,
+.arrow:before {
+  position: absolute;
+}
+
+.arrow:after {
+  position: absolute;
+}
+
+.arrow{
+  top: 105px;
+  left: 95%;
+  -webkit-transform: rotate(318deg);
+}
+
+.arrow:after{
+  content: '';
+  width:30px;
+  height: 30px;
+  margin: -10px 0 0 -10px;
+  border-left: none;
+  border-top: none;
+  border-right: 5px #2a5c8d solid;
+  border-bottom: 5px #2a5c8d solid;
+  animation-duration: 1.8s;
+  animation-iteration-count: 4;
+  animation-name: arrow;
+  animation-name: hideAnimation 0s ease-in 5s;
+  animation-fill-mode: forwards;
+}
+
+.arrow:before{
+  content: '';
+  width:20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border-left: none;
+  border-top: none;
+  border-right: 5px #2a5c8d solid;
+  border-bottom: 5px #2a5c8d solid;
+  animation-duration: 1.8s;
+  animation-iteration-count: 4;
+  animation-name: arrow;
+  animation-name: hideAnimation 0s ease-in 5s;
+  animation-fill-mode: forwards;
+}
+
+@keyframes arrow {
+  0%{ opacity: 1}
+  100%{ opacity: 0;
+    transform: translate(-10px, -10px)}
+}
+
+@keyframes hideAnimation {
+  to {
+    visibility: hidden;
+    width: 0;
+    height: 0;
+  }
 }


### PR DESCRIPTION
## Description

Added animated blinking arrow to indicate for a horizontal scroll to users when they are on the cases page. The arrow stays blinking for about 5 seconds and hides afterward.

[Trello](https://trello.com/c/iCWs6wp0/169-cases-table-indicate-that-the-user-can-scroll-horizontally)
[Loom](https://www.loom.com/share/7410ab6c58a3442e80fd49193c718bc6)

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] No duplicate code left within changed files
- [ ] Size of pull request kept to a minimum
- [ ] Pull request description clearly describes changes made & motivations for said changes
https://www.loom.com/share/7410ab6c58a3442e80fd49193c718bc6