### PR TITLE
fixed judges page visualization zoomin / white space

### DIFF
--- a/src/components/pages/JudgePage/JudgePage.js
+++ b/src/components/pages/JudgePage/JudgePage.js
@@ -125,19 +125,6 @@ export default function JudgePage(props) {
       {judge && (
         <div>
           <div className="imgBox">
-            <h3 className="judgeDisclaimer">
-              Judge {judge.first_name} {judge.middle_initial} {judge.last_name}{' '}
-              serves in the county of {judge.county}.<br></br>
-              <br></br> All visualizations regarding Judge {judge.last_name}'s
-              asylum acceptance and denial rates reflect only the data in the
-              database. As more cases are added, more data can be visualized.
-              You can find more context for individual judge data at this
-              resource's
-              <a href="https://trac.syr.edu/immigration/reports/judgereports/">
-                {' '}
-                website.
-              </a>
-            </h3>
             <h1>
               {judge.first_name +
                 ' ' +
@@ -156,6 +143,20 @@ export default function JudgePage(props) {
             >
               Biography
             </a>
+            <br></br>
+            <h3 className="judgeDisclaimer">
+              Judge {judge.first_name} {judge.middle_initial} {judge.last_name}{' '}
+              serves in the county of {judge.county}.<br></br>
+              <br></br> All visualizations regarding Judge {judge.last_name}'s
+              asylum acceptance and denial rates reflect only the data in the
+              database. As more cases are added, more data can be visualized.
+              You can find more context for individual judge data at this
+              resource's
+              <a href="https://trac.syr.edu/immigration/reports/judgereports/">
+                {' '}
+                website.
+              </a>
+            </h3>
           </div>
 
           <div className="judgeStatsVizDiv">

--- a/src/components/pages/JudgePage/JudgePage.less
+++ b/src/components/pages/JudgePage/JudgePage.less
@@ -60,13 +60,13 @@
 }
 
 .judgeStatsVizDiv {
-  width: 100%;
-  height: 80rem;
+  width: 80vw;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-content: space-evenly;
-  margin: 0 0 2rem 2rem;
+  margin-left: 2rem;
+  position: absolute;
 }
 
 .judgePageTable {


### PR DESCRIPTION
## Description

Removed white big white space on top and bottom of the graph, moved the judges name, biography and county to the top and finally made sure both the box and graph stays within the container and does not overlap to the sidebar when we zoom in.

[Trello](https://trello.com/c/e9d4hC0N/226-ui-ux-updates-for-specific-judge-page)
[Loom](https://www.loom.com/share/6f65376d871b44f1a479876fb4f46a94)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
https://www.loom.com/share/6f65376d871b44f1a479876fb4f46a94