### PR TITLE
bug/fix on cases page on horizontal arrow

### DIFF
--- a/src/components/pages/Cases/CaseTable.js
+++ b/src/components/pages/Cases/CaseTable.js
@@ -329,11 +329,10 @@ export default function CaseTable(props) {
       <div className="viz-container">
         <DecisionRateChart data={caseData} className="casesViz" />
       </div>
-
+      <div className="arrow"></div>
       <div className="case-table-container">
         <Tabs defaultActiveKey="1" className="tabs">
           <TabPane tab="Initial Cases" key="1">
-            <div className="arrow"></div>
             <div className="filterGallery">
               Filters:
               {processFilters(initialFilters).map(filter => {

--- a/src/components/pages/Cases/CaseTable.less
+++ b/src/components/pages/Cases/CaseTable.less
@@ -123,7 +123,7 @@ button.ant-btn:hover {
 }
 
 .arrow{
-  top: 105px;
+  top: 75%;
   left: 95%;
   -webkit-transform: rotate(318deg);
 }


### PR DESCRIPTION
## Description

Small changes made to the horizontal arrow indicator on cases page to stay in one place rather than moving with the scroll. The arrow was moving to the left when scrolling horizontally but now it doesn't and it should be good to go.

[Loom](https://www.loom.com/share/6e69a38c5eeb45edaa6a336db5f98de4)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] No duplicate code left within changed files
- [ ] Size of pull request kept to a minimum
- [ ] Pull request description clearly describes changes made & motivations for said changes
https://www.loom.com/share/6e69a38c5eeb45edaa6a336db5f98de4