### PR TITLE
Renamed fields to match across the Case Table

### DIFF
--- a/src/components/pages/CaseOverview/CaseOverview.js
+++ b/src/components/pages/CaseOverview/CaseOverview.js
@@ -84,7 +84,7 @@ const CaseOverview = props => {
               </p>
               <p>Applicant Gender: {caseData.applicant_gender}</p>
               <p>
-                Persecution Experienced:{' '}
+                Type of Persecution Experienced:
                 {caseData.type_of_persecution_experienced}
               </p>
               <br />


### PR DESCRIPTION
## Description

Rename fields within CaseOverview to align with naming used in Case Table. Fields in the case details module appeared different between the Cases Table and the Saved cases. Simple field change to keep the keywords consistent across pages and close out a legacy Trello Card.

Fixes # (issue)
https://trello.com/c/fH7guCUR/206-fix-case-overview-in-saved-cases
https://www.loom.com/share/2f3c4feff6334643938eca7a4ca25c57

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
